### PR TITLE
Adjust sticky actions padding for safe area insets

### DIFF
--- a/tk-kartikasari/components/StickyActions.tsx
+++ b/tk-kartikasari/components/StickyActions.tsx
@@ -5,7 +5,7 @@ import { waLink } from "@/lib/utils";
 
 export default function StickyActions() {
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 pb-6">
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 pb-[calc(env(safe-area-inset-bottom,0)+1.5rem)]">
       <div className="container pointer-events-auto">
         <div className="flex flex-col gap-4 rounded-3xl border border-border/70 bg-surface/95 px-5 py-5 shadow-soft backdrop-blur sm:flex-row sm:items-center sm:justify-between">
           <div>


### PR DESCRIPTION
## Summary
- update the sticky actions container to include the device safe area inset in its bottom padding so it clears the home indicator

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d226397524832fb28940a0383a9d18