### PR TITLE
Add accessible labeling to map iframe

### DIFF
--- a/tk-kartikasari/components/MapEmbed.tsx
+++ b/tk-kartikasari/components/MapEmbed.tsx
@@ -7,6 +7,8 @@ export default function MapEmbed() {
         className="w-full h-[320px]"
         loading="lazy"
         referrerPolicy="no-referrer-when-downgrade"
+        title="Lokasi TK Kartikasari"
+        aria-label="Lokasi TK Kartikasari"
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- add a descriptive title and aria-label to the map iframe so assistive technologies can announce it clearly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2266ecff8832fa0dc6fcc6fbf4934