### PR TITLE
Animate mobile navigation transitions

### DIFF
--- a/tk-kartikasari/components/MobileNav.tsx
+++ b/tk-kartikasari/components/MobileNav.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
 
 import { mainNav } from "@/data/navigation";
 
@@ -14,55 +15,65 @@ export default function MobileNav() {
 
   return (
     <div className="relative md:hidden">
-      <button
+      <motion.button
         type="button"
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
         aria-controls="mobile-nav"
         className="inline-flex items-center justify-center rounded-2xl border border-border/80 bg-white/80 p-2 text-text shadow-soft transition hover:border-primary hover:text-primary"
+        whileTap={{ scale: 0.95 }}
       >
         <span className="sr-only">Toggle navigation</span>
-        <svg
-          className="h-5 w-5"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.8"
-          strokeLinecap="round"
-        >
-          {open ? (
-            <path d="M18 6L6 18M6 6l12 12" />
-          ) : (
-            <path d="M4 7h16M4 12h16M4 17h16" />
-          )}
-        </svg>
-      </button>
-      {open ? (
-        <div
-          id="mobile-nav"
-          className="absolute right-0 top-12 z-50 w-64 rounded-3xl border border-border/70 bg-white p-4 shadow-xl"
-        >
-          <nav className="flex flex-col gap-1 text-sm font-medium text-text">
-            {mainNav.map((item) => {
-              const isActive = pathname === item.href;
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  onClick={closeMenu}
-                  className={`rounded-2xl px-4 py-2 transition ${
-                    isActive
-                      ? "bg-primary/10 text-primary"
-                      : "text-text-muted hover:bg-surfaceAlt hover:text-text"
-                  }`}
-                >
-                  {item.label}
-                </Link>
-              );
-            })}
-          </nav>
-        </div>
-      ) : null}
+        <span className="relative block h-5 w-6" aria-hidden>
+          <motion.span
+            className="absolute left-0 top-1 h-0.5 w-full rounded bg-current"
+            animate={open ? { rotate: 45, y: 6 } : { rotate: 0, y: 0 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+          />
+          <motion.span
+            className="absolute left-0 top-[9px] h-0.5 w-full rounded bg-current"
+            animate={open ? { opacity: 0 } : { opacity: 1 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+          />
+          <motion.span
+            className="absolute left-0 bottom-1 h-0.5 w-full rounded bg-current"
+            animate={open ? { rotate: -45, y: -6 } : { rotate: 0, y: 0 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+          />
+        </span>
+      </motion.button>
+      <AnimatePresence>
+        {open ? (
+          <motion.div
+            id="mobile-nav"
+            className="absolute right-0 top-12 z-50 w-64 rounded-3xl border border-border/70 bg-white p-4 shadow-xl"
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+          >
+            <nav className="flex flex-col gap-1 text-sm font-medium text-text">
+              {mainNav.map((item) => {
+                const isActive = pathname === item.href;
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    onClick={closeMenu}
+                    className={`rounded-2xl px-4 py-2 transition ${
+                      isActive
+                        ? "bg-primary/10 text-primary"
+                        : "text-text-muted hover:bg-surfaceAlt hover:text-text"
+                    }`}
+                  >
+                    {item.label}
+                  </Link>
+                );
+              })}
+            </nav>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- animate the mobile navigation menu with framer-motion so it fades and slides when toggled
- morph the hamburger button into a close icon with motion-driven feedback while tapping

## Testing
- npm run build
- Manual small-screen Playwright check

------
https://chatgpt.com/codex/tasks/task_e_68d2378ca240832fa3fa72c6dc08d03e