### PR TITLE
Add localized empty states for agenda, gallery, testimonials

### DIFF
--- a/tk-kartikasari/app/agenda/page.tsx
+++ b/tk-kartikasari/app/agenda/page.tsx
@@ -15,6 +15,7 @@ export default function Page() {
   const items = [...agenda].sort(
     (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
   );
+  const hasItems = items.length > 0;
 
   return (
     <div className="container py-8 space-y-6">
@@ -27,27 +28,36 @@ export default function Page() {
         </p>
       </header>
 
-      <ul className="space-y-3">
-        {items.map((item: AgendaItem) => (
-          <li key={item.id} className="card p-5">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <div>
-                <h2 className="text-xl font-semibold text-text">{item.title}</h2>
-                <p className="text-sm text-text-muted">{formatDate(item.date)}</p>
+      {hasItems ? (
+        <ul className="space-y-3">
+          {items.map((item: AgendaItem) => (
+            <li key={item.id} className="card p-5">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-xl font-semibold text-text">{item.title}</h2>
+                  <p className="text-sm text-text-muted">{formatDate(item.date)}</p>
+                </div>
+                <div className="rounded-2xl bg-secondary/10 px-4 py-2 text-sm font-semibold text-secondary">
+                  {item.time}
+                </div>
               </div>
-              <div className="rounded-2xl bg-secondary/10 px-4 py-2 text-sm font-semibold text-secondary">
-                {item.time}
+              <div className="mt-3 space-y-2 text-sm text-text-muted">
+                <p>
+                  <strong className="font-semibold text-text">Lokasi:</strong> {item.location}
+                </p>
+                <p>{item.description}</p>
               </div>
-            </div>
-            <div className="mt-3 space-y-2 text-sm text-text-muted">
-              <p>
-                <strong className="font-semibold text-text">Lokasi:</strong> {item.location}
-              </p>
-              <p>{item.description}</p>
-            </div>
-          </li>
-        ))}
-      </ul>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="card border border-border/70 bg-secondary/5 p-6 text-center">
+          <h2 className="text-lg font-semibold text-text">Belum ada agenda terbaru</h2>
+          <p className="mt-2 text-sm text-text-muted">
+            Kami sedang memperbarui jadwal kegiatan. Silakan cek kembali atau hubungi pihak sekolah untuk informasi terbaru.
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/tk-kartikasari/app/galeri/page.tsx
+++ b/tk-kartikasari/app/galeri/page.tsx
@@ -1,8 +1,12 @@
+import Link from "next/link";
+
 import data from "@/data/galeri.json";
 
 type GaleriItem = (typeof data)[number];
 
 export default function Page() {
+  const hasPhotos = data.length > 0;
+
   return (
     <div className="container py-8 space-y-6">
       <header className="space-y-3">
@@ -14,25 +18,40 @@ export default function Page() {
         </p>
       </header>
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {data.map((item: GaleriItem) => (
-          <figure
-            key={item.id}
-            className="overflow-hidden rounded-3xl border border-border/60 bg-white shadow-sm transition hover:shadow-soft"
-          >
-            <img
-              src={item.src}
-              alt={item.alt}
-              loading="lazy"
-              className="h-56 w-full object-cover"
-            />
-            <figcaption className="space-y-1 p-4 text-sm">
-              <p className="font-semibold text-text">{item.caption}</p>
-              <p className="text-xs text-text-muted">{item.alt}</p>
-            </figcaption>
-          </figure>
-        ))}
-      </div>
+      {hasPhotos ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {data.map((item: GaleriItem) => (
+            <figure
+              key={item.id}
+              className="overflow-hidden rounded-3xl border border-border/60 bg-white shadow-sm transition hover:shadow-soft"
+            >
+              <img
+                src={item.src}
+                alt={item.alt}
+                loading="lazy"
+                className="h-56 w-full object-cover"
+              />
+              <figcaption className="space-y-1 p-4 text-sm">
+                <p className="font-semibold text-text">{item.caption}</p>
+                <p className="text-xs text-text-muted">{item.alt}</p>
+              </figcaption>
+            </figure>
+          ))}
+        </div>
+      ) : (
+        <div className="card border border-border/70 bg-secondary/5 p-8 text-center">
+          <h2 className="text-xl font-semibold text-text">Dokumentasi segera hadir</h2>
+          <p className="mt-3 text-sm text-text-muted">
+            Tim kami sedang mengkurasi foto kegiatan terbaru agar dapat dibagikan kepada orang tua. Jika Anda membutuhkan
+            informasi tambahan, silakan hubungi kami melalui kanal resmi sekolah.
+          </p>
+          <div className="mt-6 flex justify-center">
+            <Link href="/kontak" className="btn-primary w-full sm:w-auto">
+              Hubungi TK Kartikasari
+            </Link>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/tk-kartikasari/components/TestimonialList.tsx
+++ b/tk-kartikasari/components/TestimonialList.tsx
@@ -4,6 +4,22 @@ import data from "@/data/testimonials.json";
 import { LazyMotion, domAnimation, m } from "framer-motion";
 
 export default function TestimonialList() {
+  if (data.length === 0) {
+    return (
+      <section id="testimonials" className="py-20">
+        <div className="container">
+          <div className="card mx-auto max-w-3xl border border-border/70 bg-secondary/5 p-8 text-center text-text-muted">
+            <h2 className="text-2xl font-semibold text-text">Testimoni segera hadir</h2>
+            <p className="mt-3 text-sm">
+              Kami sedang menghimpun cerita terbaru dari orang tua murid. Kembali lagi nanti untuk membaca pengalaman mereka
+              bersama TK Kartikasari.
+            </p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
   return (
     <LazyMotion features={domAnimation}>
       <section id="testimonials" className="relative overflow-hidden py-20">


### PR DESCRIPTION
## Summary
- add a bordered empty state card to the agenda page when no kegiatan are scheduled
- show a friendly gallery placeholder with a contact CTA when no photo data is available
- render a muted "coming soon" panel in the testimonial list when data is empty

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d237fd8b90832fbadd67f9c70b9c5e