### PR TITLE
Adjust container padding for small screens

### DIFF
--- a/tk-kartikasari/app/globals.css
+++ b/tk-kartikasari/app/globals.css
@@ -24,7 +24,7 @@ body {
 }
 
 .container {
-  @apply mx-auto w-full max-w-6xl px-6 sm:px-10;
+  @apply mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-10;
 }
 
 .card {


### PR DESCRIPTION
## Summary
- reduce the base container padding and add sm/lg overrides to reclaim space on compact viewports

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d23a1625b4832fac0b1bfe03cbf78f