### PR TITLE
Adjust hero stats grid breakpoints

### DIFF
--- a/tk-kartikasari/components/home/HomePageContent.tsx
+++ b/tk-kartikasari/components/home/HomePageContent.tsx
@@ -88,7 +88,7 @@ export default function HomePageContent({
                   Lihat program unggulan
                 </a>
               </div>
-              <dl className="grid gap-6 pt-6 sm:grid-cols-3">
+              <dl className="grid gap-6 pt-6 sm:grid-cols-2 md:grid-cols-3">
                 {stats.map((item) => (
                   <div
                     key={item.label}


### PR DESCRIPTION
## Summary
- update the hero stats definition list to switch to two columns on small tablets and three columns on medium screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d23a17e188832f9c316fc2adda0c0b