### PR TITLE
Adjust sticky actions text for readability

### DIFF
--- a/tk-kartikasari/components/StickyActions.tsx
+++ b/tk-kartikasari/components/StickyActions.tsx
@@ -10,7 +10,7 @@ export default function StickyActions() {
         <div className="flex flex-col gap-4 rounded-3xl border border-border/70 bg-surface/95 px-5 py-5 shadow-soft backdrop-blur sm:flex-row sm:items-center sm:justify-between">
           <div>
             <p className="text-sm font-semibold text-primary">Siap membantu orang tua baru</p>
-            <p className="text-xs text-text-muted sm:text-sm">
+            <p className="text-sm text-text-muted sm:text-base">
               Hubungi Bu Mintarsih atau dapatkan petunjuk arah menuju sekolah kami.
             </p>
           </div>


### PR DESCRIPTION
## Summary
- raise the sticky actions supporting paragraph to a base text size for better readability on small screens
- keep the larger text scaling up at the small breakpoint to preserve layout balance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d23a1a30dc832fbe95a5efea98139f