### PR TITLE
Make mobile nav drawer responsive

### DIFF
--- a/tk-kartikasari/components/MobileNav.tsx
+++ b/tk-kartikasari/components/MobileNav.tsx
@@ -40,7 +40,7 @@ export default function MobileNav() {
       {open ? (
         <div
           id="mobile-nav"
-          className="absolute right-0 top-12 z-50 w-[min(16rem,calc(100vw-3rem))] rounded-3xl border border-border/70 bg-white p-4 shadow-xl"
+          className="absolute right-0 top-12 z-50 w-64 max-w-[calc(100vw-3rem)] rounded-3xl border border-border/70 bg-white p-4 shadow-xl"
         >
           <nav className="flex flex-col gap-1 text-sm font-medium text-text">
             {mainNav.map((item) => {


### PR DESCRIPTION
## Summary
- adjust the mobile navigation drawer width to cap at the viewport width so it stays on screen on narrow devices

## Testing
- npm run build
- Manual verification on a 360px-wide viewport (screenshot included)


------
https://chatgpt.com/codex/tasks/task_e_68d23a1ee080832f99d3f3e8fd25d787