### PR TITLE
Create shared PageHeader component

### DIFF
--- a/tk-kartikasari/app/agenda/page.tsx
+++ b/tk-kartikasari/app/agenda/page.tsx
@@ -1,4 +1,6 @@
+import PageHeader from "@/components/PageHeader";
 import agenda from "@/data/agenda.json";
+import { agendaPageHeader } from "@/data/content";
 
 type AgendaItem = (typeof agenda)[number];
 
@@ -18,14 +20,7 @@ export default function Page() {
 
   return (
     <div className="container py-8 space-y-6">
-      <header className="space-y-3">
-        <p className="text-sm font-semibold uppercase tracking-wide text-secondary">Agenda</p>
-        <h1 className="text-3xl font-bold sm:text-4xl">Agenda Kegiatan TK Kartikasari</h1>
-        <p className="max-w-2xl text-text-muted">
-          Agenda disusun untuk melibatkan anak dan orang tua dalam pengalaman belajar yang menyenangkan serta penuh kolaborasi.
-          Simpan tanggal penting berikut di kalender keluarga Anda.
-        </p>
-      </header>
+      <PageHeader {...agendaPageHeader} />
 
       <ul className="space-y-3">
         {items.map((item: AgendaItem) => (

--- a/tk-kartikasari/app/galeri/page.tsx
+++ b/tk-kartikasari/app/galeri/page.tsx
@@ -1,18 +1,13 @@
+import PageHeader from "@/components/PageHeader";
 import data from "@/data/galeri.json";
+import { galeriPageHeader } from "@/data/content";
 
 type GaleriItem = (typeof data)[number];
 
 export default function Page() {
   return (
     <div className="container py-8 space-y-6">
-      <header className="space-y-3">
-        <p className="text-sm font-semibold uppercase tracking-wide text-secondary">Galeri</p>
-        <h1 className="text-3xl font-bold sm:text-4xl">Galeri Kegiatan Anak</h1>
-        <p className="max-w-2xl text-text-muted">
-          Potret kegiatan anak TK Kartikasari dalam suasana belajar yang hangat, aktif, dan menyenangkan. Semua foto dimuat
-          dengan teknik lazy-load agar halaman tetap ringan.
-        </p>
-      </header>
+      <PageHeader {...galeriPageHeader} />
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {data.map((item: GaleriItem) => (

--- a/tk-kartikasari/app/kontak/page.tsx
+++ b/tk-kartikasari/app/kontak/page.tsx
@@ -1,6 +1,8 @@
-import site from "@/data/site.json";
-import MapEmbed from "@/components/MapEmbed";
 import CTAButton from "@/components/CTAButton";
+import MapEmbed from "@/components/MapEmbed";
+import PageHeader from "@/components/PageHeader";
+import site from "@/data/site.json";
+import { kontakPageHeader } from "@/data/content";
 
 const info = [
   { label: "Alamat", value: site.address },
@@ -12,14 +14,7 @@ const info = [
 export default function Page() {
   return (
     <div className="container py-8 space-y-6">
-      <header className="space-y-3">
-        <p className="text-sm font-semibold uppercase tracking-wide text-secondary">Kontak</p>
-        <h1 className="text-3xl font-bold sm:text-4xl">Hubungi TK Kartikasari</h1>
-        <p className="max-w-2xl text-text-muted">
-          Kami siap membantu informasi seputar PPDB, jadwal kunjungan sekolah, maupun kebutuhan administrasi lainnya. Gunakan
-          detail di bawah ini atau langsung hubungi kami melalui WhatsApp.
-        </p>
-      </header>
+      <PageHeader {...kontakPageHeader} />
 
       <section className="grid gap-4 md:grid-cols-[1.1fr,0.9fr] md:items-start">
         <div className="card p-6 space-y-4">

--- a/tk-kartikasari/app/ppdb/page.tsx
+++ b/tk-kartikasari/app/ppdb/page.tsx
@@ -1,6 +1,8 @@
 import CTAButton from "@/components/CTAButton";
+import PageHeader from "@/components/PageHeader";
 import PpdbForm from "@/components/PpdbForm";
 import site from "@/data/site.json";
+import { ppdbPageHeader } from "@/data/content";
 
 const steps = [
   "Hubungi Ibu Mintarsih melalui WhatsApp untuk mengatur jadwal kunjungan sekolah.",
@@ -35,14 +37,16 @@ const faqs = [
 export default function Page() {
   return (
     <div className="container py-8 space-y-8">
-      <header className="max-w-3xl space-y-3">
-        <p className="text-sm font-semibold uppercase tracking-wide text-secondary">PPDB</p>
-        <h1 className="text-3xl font-bold sm:text-4xl">Penerimaan Peserta Didik Baru</h1>
-        <p className="text-text-muted">
-          Kami menyambut keluarga baru yang ingin bergabung dengan TK Kartikasari. Silakan ikuti alur pendaftaran berikut atau
-          hubungi langsung kepala sekolah melalui WhatsApp.
-        </p>
-      </header>
+      <PageHeader
+        {...ppdbPageHeader}
+        className="max-w-3xl"
+        actions={
+          <CTAButton
+            label="Chat Kepala Sekolah"
+            message="Halo Bu Mintarsih, saya ingin mendapatkan info lengkap PPDB TK Kartikasari."
+          />
+        }
+      />
 
       <section className="card p-6 space-y-4">
         <div>
@@ -54,12 +58,6 @@ export default function Page() {
             <li key={step}>{step}</li>
           ))}
         </ol>
-        <div className="pt-2">
-          <CTAButton
-            label="Chat Kepala Sekolah"
-            message="Halo Bu Mintarsih, saya ingin mendapatkan info lengkap PPDB TK Kartikasari."
-          />
-        </div>
       </section>
 
       <section className="card p-6 space-y-5">

--- a/tk-kartikasari/app/program/page.tsx
+++ b/tk-kartikasari/app/program/page.tsx
@@ -1,3 +1,6 @@
+import PageHeader from "@/components/PageHeader";
+import { programPageHeader } from "@/data/content";
+
 const classes = [
   {
     name: "Kelas A • Bintang Kecil",
@@ -77,14 +80,11 @@ const weeklySchedule = [
 export default function Page() {
   return (
     <div className="container py-8 space-y-10">
-      <header className="max-w-3xl space-y-3">
-        <p className="text-sm font-semibold uppercase tracking-wide text-secondary">Program Pembelajaran</p>
-        <h1 className="text-3xl font-bold sm:text-4xl">Program & Kegiatan TK Kartikasari</h1>
-        <p className="text-text-muted">
-          Program dirancang untuk menstimulasi seluruh aspek perkembangan anak usia dini dengan pendekatan bermain yang bermakna
-          dan dukungan kolaboratif antara guru serta orang tua.
-        </p>
-      </header>
+      <PageHeader
+        {...programPageHeader}
+        className="max-w-3xl"
+        descriptionClassName="text-text-muted"
+      />
 
       <section className="grid gap-4 lg:grid-cols-2">
         {classes.map((item) => (

--- a/tk-kartikasari/app/tentang/page.tsx
+++ b/tk-kartikasari/app/tentang/page.tsx
@@ -1,4 +1,6 @@
+import PageHeader from "@/components/PageHeader";
 import site from "@/data/site.json";
+import { tentangPageHeader } from "@/data/content";
 
 const profileItems = [
   { label: "Nama Sekolah", value: site.schoolName },
@@ -19,14 +21,11 @@ const mission = [
 export default function Page() {
   return (
     <div className="container py-8 space-y-8">
-      <header className="max-w-3xl space-y-3">
-        <p className="text-sm font-semibold uppercase tracking-wide text-secondary">Tentang Sekolah</p>
-        <h1 className="text-3xl font-bold sm:text-4xl">TK Kartikasari</h1>
-        <p className="text-text-muted">
-          TK Kartikasari hadir sebagai lingkungan bermain-belajar yang hangat bagi anak usia dini di Bantarsari, Cilacap.
-          Kami berfokus pada stimulasi kemandirian, kreativitas, dan karakter melalui kegiatan tematik yang menyenangkan.
-        </p>
-      </header>
+      <PageHeader
+        {...tentangPageHeader}
+        className="max-w-3xl"
+        descriptionClassName="text-text-muted"
+      />
 
       <section id="sambutan" className="card p-6 space-y-4">
         <div>

--- a/tk-kartikasari/components/PageHeader.tsx
+++ b/tk-kartikasari/components/PageHeader.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+
+type PageHeaderProps = {
+  eyebrow: string;
+  title: string;
+  description?: string;
+  className?: string;
+  descriptionClassName?: string;
+  actions?: ReactNode;
+};
+
+function cx(...classes: Array<string | undefined | null | false>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export default function PageHeader({
+  eyebrow,
+  title,
+  description,
+  className,
+  descriptionClassName,
+  actions,
+}: PageHeaderProps) {
+  return (
+    <header className={cx("space-y-3", className)}>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between sm:gap-6">
+        <div className="space-y-3">
+          <p className="text-sm font-semibold uppercase tracking-wide text-secondary">{eyebrow}</p>
+          <h1 className="text-3xl font-bold sm:text-4xl">{title}</h1>
+          {description ? (
+            <p className={descriptionClassName ?? "max-w-2xl text-text-muted"}>{description}</p>
+          ) : null}
+        </div>
+        {actions ? (
+          <div className="flex flex-col items-start gap-2 sm:items-end">{actions}</div>
+        ) : null}
+      </div>
+    </header>
+  );
+}

--- a/tk-kartikasari/data/content/agenda.ts
+++ b/tk-kartikasari/data/content/agenda.ts
@@ -1,0 +1,8 @@
+import type { PageHeaderContent } from "./types";
+
+export const agendaPageHeader: PageHeaderContent = {
+  eyebrow: "Agenda",
+  title: "Agenda Kegiatan TK Kartikasari",
+  description:
+    "Agenda disusun untuk melibatkan anak dan orang tua dalam pengalaman belajar yang menyenangkan serta penuh kolaborasi. Simpan tanggal penting berikut di kalender keluarga Anda.",
+};

--- a/tk-kartikasari/data/content/galeri.ts
+++ b/tk-kartikasari/data/content/galeri.ts
@@ -1,0 +1,8 @@
+import type { PageHeaderContent } from "./types";
+
+export const galeriPageHeader: PageHeaderContent = {
+  eyebrow: "Galeri",
+  title: "Galeri Kegiatan Anak",
+  description:
+    "Potret kegiatan anak TK Kartikasari dalam suasana belajar yang hangat, aktif, dan menyenangkan. Semua foto dimuat dengan teknik lazy-load agar halaman tetap ringan.",
+};

--- a/tk-kartikasari/data/content/index.ts
+++ b/tk-kartikasari/data/content/index.ts
@@ -1,0 +1,8 @@
+export type { PageHeaderContent } from "./types";
+
+export { agendaPageHeader } from "./agenda";
+export { galeriPageHeader } from "./galeri";
+export { programPageHeader } from "./program";
+export { ppdbPageHeader } from "./ppdb";
+export { tentangPageHeader } from "./tentang";
+export { kontakPageHeader } from "./kontak";

--- a/tk-kartikasari/data/content/kontak.ts
+++ b/tk-kartikasari/data/content/kontak.ts
@@ -1,0 +1,8 @@
+import type { PageHeaderContent } from "./types";
+
+export const kontakPageHeader: PageHeaderContent = {
+  eyebrow: "Kontak",
+  title: "Hubungi TK Kartikasari",
+  description:
+    "Kami siap membantu informasi seputar PPDB, jadwal kunjungan sekolah, maupun kebutuhan administrasi lainnya. Gunakan detail di bawah ini atau langsung hubungi kami melalui WhatsApp.",
+};

--- a/tk-kartikasari/data/content/ppdb.ts
+++ b/tk-kartikasari/data/content/ppdb.ts
@@ -1,0 +1,8 @@
+import type { PageHeaderContent } from "./types";
+
+export const ppdbPageHeader: PageHeaderContent = {
+  eyebrow: "PPDB",
+  title: "Penerimaan Peserta Didik Baru",
+  description:
+    "Kami menyambut keluarga baru yang ingin bergabung dengan TK Kartikasari. Silakan ikuti alur pendaftaran berikut atau hubungi langsung kepala sekolah melalui WhatsApp.",
+};

--- a/tk-kartikasari/data/content/program.ts
+++ b/tk-kartikasari/data/content/program.ts
@@ -1,0 +1,8 @@
+import type { PageHeaderContent } from "./types";
+
+export const programPageHeader: PageHeaderContent = {
+  eyebrow: "Program Pembelajaran",
+  title: "Program & Kegiatan TK Kartikasari",
+  description:
+    "Program dirancang untuk menstimulasi seluruh aspek perkembangan anak usia dini dengan pendekatan bermain yang bermakna dan dukungan kolaboratif antara guru serta orang tua.",
+};

--- a/tk-kartikasari/data/content/tentang.ts
+++ b/tk-kartikasari/data/content/tentang.ts
@@ -1,0 +1,8 @@
+import type { PageHeaderContent } from "./types";
+
+export const tentangPageHeader: PageHeaderContent = {
+  eyebrow: "Tentang Sekolah",
+  title: "TK Kartikasari",
+  description:
+    "TK Kartikasari hadir sebagai lingkungan bermain-belajar yang hangat bagi anak usia dini di Bantarsari, Cilacap. Kami berfokus pada stimulasi kemandirian, kreativitas, dan karakter melalui kegiatan tematik yang menyenangkan.",
+};

--- a/tk-kartikasari/data/content/types.ts
+++ b/tk-kartikasari/data/content/types.ts
@@ -1,0 +1,5 @@
+export type PageHeaderContent = {
+  eyebrow: string;
+  title: string;
+  description?: string;
+};


### PR DESCRIPTION
## Summary
- add a reusable PageHeader component with support for optional actions and custom styling hooks
- move page header copy into data/content modules for reuse across static pages
- update agenda, galeri, program, ppdb, tentang, and kontak routes to render the shared header component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d23aad0e5c832fb069b05ea6788add