### PR TITLE
refactor: centralize CTA configurations

### DIFF
--- a/tk-kartikasari/app/kontak/page.tsx
+++ b/tk-kartikasari/app/kontak/page.tsx
@@ -1,6 +1,7 @@
 import site from "@/data/site.json";
 import MapEmbed from "@/components/MapEmbed";
 import CTAButton from "@/components/CTAButton";
+import { contactConsultationCTA } from "@/content/cta";
 
 const info = [
   { label: "Alamat", value: site.address },
@@ -33,11 +34,7 @@ export default function Page() {
             ))}
           </ul>
           <div className="pt-2">
-            <CTAButton
-              label="Chat via WhatsApp"
-              message="Halo Bu Mintarsih, saya ingin berkonsultasi mengenai TK Kartikasari."
-              className="w-full sm:w-auto"
-            />
+            <CTAButton config={contactConsultationCTA} className="w-full sm:w-auto" />
           </div>
         </div>
         <div className="card p-6 space-y-3 bg-secondary/5 text-sm text-text-muted">

--- a/tk-kartikasari/app/page.tsx
+++ b/tk-kartikasari/app/page.tsx
@@ -1,4 +1,5 @@
 import HomePageContent from "@/components/home/HomePageContent";
+import { faqInquiryCTA, heroVisitCTA, visitScheduleCTA } from "@/content/cta";
 import site from "@/data/site.json";
 
 const stats = [
@@ -130,6 +131,9 @@ export default function Page() {
       programs={programs}
       journey={journey}
       faqs={faqs}
+      heroCta={heroVisitCTA}
+      faqCta={faqInquiryCTA}
+      visitCta={visitScheduleCTA}
     />
   );
 }

--- a/tk-kartikasari/app/ppdb/page.tsx
+++ b/tk-kartikasari/app/ppdb/page.tsx
@@ -1,5 +1,6 @@
 import CTAButton from "@/components/CTAButton";
 import PpdbForm from "@/components/PpdbForm";
+import { ppdbHeadmasterCTA } from "@/content/cta";
 import site from "@/data/site.json";
 
 const steps = [
@@ -55,10 +56,7 @@ export default function Page() {
           ))}
         </ol>
         <div className="pt-2">
-          <CTAButton
-            label="Chat Kepala Sekolah"
-            message="Halo Bu Mintarsih, saya ingin mendapatkan info lengkap PPDB TK Kartikasari."
-          />
+          <CTAButton config={ppdbHeadmasterCTA} />
         </div>
       </section>
 

--- a/tk-kartikasari/components/CTAButton.tsx
+++ b/tk-kartikasari/components/CTAButton.tsx
@@ -1,20 +1,38 @@
 "use client";
 
+import { generalInquiryCTA, type CTAConfig, type CTAKey, ctaConfigs } from "@/content/cta";
 import { waLink } from "@/lib/utils";
 
+const variantClassNames = {
+  primary: "btn-primary",
+  outline: "btn-outline",
+} as const;
+
 type Props = {
+  config?: CTAConfig;
+  configKey?: CTAKey;
   label?: string;
   message?: string;
   className?: string;
+  variant?: CTAConfig["variant"];
 };
 
 export default function CTAButton({
-  label = "Chat via WhatsApp",
-  message = "Halo Bu Mintarsih, saya ingin info PPDB TK Kartikasari.",
+  config,
+  configKey,
+  label,
+  message,
   className,
+  variant,
 }: Props) {
+  const resolvedConfig = config ?? (configKey ? ctaConfigs[configKey] : undefined);
+  const finalLabel = label ?? resolvedConfig?.label ?? generalInquiryCTA.label;
+  const finalMessage = message ?? resolvedConfig?.message ?? generalInquiryCTA.message;
+  const finalVariant = variant ?? resolvedConfig?.variant ?? generalInquiryCTA.variant ?? "primary";
+  const variantClass = variantClassNames[finalVariant] ?? variantClassNames.primary;
+
   const classes = [
-    "btn-primary",
+    variantClass,
     "group",
     "hover:-translate-y-0.5",
     "focus-visible:outline-none",
@@ -26,7 +44,7 @@ export default function CTAButton({
     .join(" ");
 
   return (
-    <a href={waLink(message)} className={classes}>
+    <a href={waLink(finalMessage)} className={classes}>
       <span className="flex items-center gap-3">
         <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/20 text-white transition group-hover:bg-white/30">
           <svg
@@ -54,7 +72,7 @@ export default function CTAButton({
             />
           </svg>
         </span>
-        <span className="text-base">{label}</span>
+        <span className="text-base">{finalLabel}</span>
       </span>
     </a>
   );

--- a/tk-kartikasari/components/StickyActions.tsx
+++ b/tk-kartikasari/components/StickyActions.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import CTAButton from "@/components/CTAButton";
+import { generalInquiryCTA } from "@/content/cta";
 import site from "@/data/site.json";
-import { waLink } from "@/lib/utils";
 
 export default function StickyActions() {
   return (
@@ -15,12 +16,7 @@ export default function StickyActions() {
             </p>
           </div>
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-            <a
-              href={waLink("Halo Bu Mintarsih, saya ingin info PPDB TK Kartikasari.")}
-              className="btn-primary w-full sm:w-auto"
-            >
-              Chat via WhatsApp
-            </a>
+            <CTAButton config={generalInquiryCTA} className="w-full sm:w-auto" />
             <a
               href={site.mapsUrl}
               target="_blank"

--- a/tk-kartikasari/components/home/HomePageContent.tsx
+++ b/tk-kartikasari/components/home/HomePageContent.tsx
@@ -3,6 +3,7 @@
 import CTAButton from "@/components/CTAButton";
 import StickyActions from "@/components/StickyActions";
 import TestimonialList from "@/components/TestimonialList";
+import type { CTAConfig } from "@/content/cta";
 import { LazyMotion, domAnimation, m } from "framer-motion";
 
 type StatsItem = {
@@ -42,6 +43,9 @@ type HomePageContentProps = {
   programs: ProgramItem[];
   journey: JourneyItem[];
   faqs: FAQItem[];
+  heroCta: CTAConfig;
+  faqCta: CTAConfig;
+  visitCta: CTAConfig;
 };
 
 export default function HomePageContent({
@@ -51,6 +55,9 @@ export default function HomePageContent({
   programs,
   journey,
   faqs,
+  heroCta,
+  faqCta,
+  visitCta,
 }: HomePageContentProps) {
   return (
     <LazyMotion features={domAnimation}>
@@ -79,11 +86,7 @@ export default function HomePageContent({
                 Lingkungan hangat, fasilitas aman, dan kegiatan tematik yang menumbuhkan rasa ingin tahu anak usia dini di Bantarsari, Cilacap.
               </p>
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
-                <CTAButton
-                  label="Daftar PPDB & Tur Sekolah"
-                  className="w-full sm:w-auto"
-                  message="Halo Bu Mintarsih, saya ingin menjadwalkan kunjungan dan mendapatkan info PPDB TK Kartikasari."
-                />
+                <CTAButton config={heroCta} className="w-full sm:w-auto" />
                 <a href="#program" className="btn-outline w-full sm:w-auto">
                   Lihat program unggulan
                 </a>
@@ -360,11 +363,7 @@ export default function HomePageContent({
               <p className="text-lg leading-relaxed text-text-muted">
                 Jika ada pertanyaan lain, kami dengan senang hati menjawab melalui WhatsApp ataupun ketika Anda berkunjung langsung.
               </p>
-              <CTAButton
-                label="Tanya langsung via WhatsApp"
-                className="w-full sm:w-auto"
-                message="Halo Bu Mintarsih, saya ingin menanyakan informasi mengenai TK Kartikasari."
-              />
+              <CTAButton config={faqCta} className="w-full sm:w-auto" />
             </m.div>
             <div className="space-y-4">
               {faqs.map((faq, index) => (
@@ -405,11 +404,7 @@ export default function HomePageContent({
                 </p>
               </div>
               <div className="flex flex-col gap-3 md:flex-row md:items-center">
-                <CTAButton
-                  label="Jadwalkan kunjungan"
-                  className="w-full md:w-auto"
-                  message="Halo Bu Mintarsih, saya ingin menjadwalkan tur sekolah TK Kartikasari."
-                />
+                <CTAButton config={visitCta} className="w-full md:w-auto" />
                 <a href="#program" className="btn-outline w-full md:w-auto">
                   Lihat program kembali
                 </a>

--- a/tk-kartikasari/content/cta.ts
+++ b/tk-kartikasari/content/cta.ts
@@ -1,0 +1,55 @@
+export type CTAButtonVariant = "primary" | "outline";
+
+export type CTAConfig = {
+  label: string;
+  message: string;
+  variant?: CTAButtonVariant;
+};
+
+export const generalInquiryCTA: CTAConfig = {
+  label: "Chat via WhatsApp",
+  message: "Halo Bu Mintarsih, saya ingin info PPDB TK Kartikasari.",
+  variant: "primary",
+};
+
+export const heroVisitCTA: CTAConfig = {
+  label: "Daftar PPDB & Tur Sekolah",
+  message:
+    "Halo Bu Mintarsih, saya ingin menjadwalkan kunjungan dan mendapatkan info PPDB TK Kartikasari.",
+  variant: "primary",
+};
+
+export const faqInquiryCTA: CTAConfig = {
+  label: "Tanya langsung via WhatsApp",
+  message: "Halo Bu Mintarsih, saya ingin menanyakan informasi mengenai TK Kartikasari.",
+  variant: "primary",
+};
+
+export const visitScheduleCTA: CTAConfig = {
+  label: "Jadwalkan kunjungan",
+  message: "Halo Bu Mintarsih, saya ingin menjadwalkan tur sekolah TK Kartikasari.",
+  variant: "primary",
+};
+
+export const contactConsultationCTA: CTAConfig = {
+  label: "Chat via WhatsApp",
+  message: "Halo Bu Mintarsih, saya ingin berkonsultasi mengenai TK Kartikasari.",
+  variant: "primary",
+};
+
+export const ppdbHeadmasterCTA: CTAConfig = {
+  label: "Chat Kepala Sekolah",
+  message: "Halo Bu Mintarsih, saya ingin mendapatkan info lengkap PPDB TK Kartikasari.",
+  variant: "primary",
+};
+
+export const ctaConfigs = {
+  generalInquiry: generalInquiryCTA,
+  heroVisit: heroVisitCTA,
+  faqInquiry: faqInquiryCTA,
+  visitSchedule: visitScheduleCTA,
+  contactConsultation: contactConsultationCTA,
+  ppdbHeadmaster: ppdbHeadmasterCTA,
+} as const;
+
+export type CTAKey = keyof typeof ctaConfigs;


### PR DESCRIPTION
## Summary
- add a shared content/cta module containing reusable WhatsApp CTA definitions
- teach CTAButton to resolve label/message/variant from the shared configs while keeping override hooks
- wire homepage, contact, PPDB, and sticky actions to consume the centralized CTA data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d23aa6386c832f84832ed0b2b28409