### PR TITLE
Refine header layout

### DIFF
--- a/tk-kartikasari/app/layout.tsx
+++ b/tk-kartikasari/app/layout.tsx
@@ -4,7 +4,7 @@ import site from "@/data/site.json";
 import Link from "next/link";
 import { waLink } from "@/lib/utils";
 import MobileNav from "@/components/MobileNav";
-import { mainNav } from "@/data/navigation";
+import DesktopNav from "@/components/DesktopNav";
 
 export const metadata: Metadata = {
   title: "TK Kartikasari Bulaksari Bantarsari Cilacap — Taman Kanak-kanak",
@@ -17,42 +17,43 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="id">
       <body className="bg-surfaceAlt text-text font-sans">
         <div className="relative min-h-screen">
-          <header className="sticky top-0 z-40 border-b border-white/40 bg-white/80 backdrop-blur">
-            <div className="container flex h-20 items-center justify-between gap-6">
-              <Link href="/" className="flex items-center gap-3">
-                <img src={site.logo} alt="Logo TK Kartikasari" className="h-12 w-12 rounded-2xl border border-white/70 bg-white p-2 shadow-soft" />
-                <div>
-                  <p className="text-lg font-semibold text-text">{site.schoolName}</p>
-                  <p className="text-sm text-text-muted">Bulaksari, Bantarsari, Cilacap</p>
-                </div>
-              </Link>
-              <nav className="hidden items-center gap-6 text-sm font-medium text-text-muted md:flex">
-                {mainNav.map((item) => (
-                  <Link key={item.href} href={item.href} className="transition hover:text-text">
-                    {item.label}
+          <header className="sticky top-0 z-50 border-b border-white/60 bg-white/90 shadow-sm backdrop-blur">
+            <div className="container">
+              <div className="flex w-full items-center gap-3 py-3 md:gap-5 md:py-4">
+                <Link
+                  href="/"
+                  className="flex shrink-0 items-center gap-3 text-text transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                >
+                  <span className="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/70 bg-white shadow-soft">
+                    <img src={site.logo} alt="Logo TK Kartikasari" className="h-8 w-8 object-contain" />
+                  </span>
+                  <span className="flex min-w-0 flex-col leading-tight">
+                    <span className="truncate text-base font-semibold md:text-lg">{site.schoolName}</span>
+                    <span className="hidden text-xs text-text-muted sm:inline">Bulaksari, Bantarsari, Cilacap</span>
+                  </span>
+                </Link>
+                <DesktopNav />
+                <div className="flex shrink-0 items-center gap-2 sm:gap-3">
+                  <Link
+                    href="/ppdb"
+                    className="hidden rounded-full border border-border/70 px-4 py-2 text-sm font-semibold text-text transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 md:inline-flex"
+                  >
+                    Info PPDB
                   </Link>
-                ))}
-              </nav>
-              <div className="flex items-center gap-3">
-                <Link
-                  href="/ppdb"
-                  className="hidden rounded-2xl border border-border/80 px-5 py-2.5 text-sm font-semibold text-text hover:border-primary hover:text-primary md:inline-flex"
-                >
-                  Info PPDB
-                </Link>
-                <a
-                  href={waLink("Halo Bu Mintarsih, saya ingin info PPDB TK Kartikasari.")}
-                  className="btn-primary hidden text-sm md:inline-flex"
-                >
-                  Chat WhatsApp
-                </a>
-                <Link
-                  href="/ppdb"
-                  className="inline-flex rounded-2xl border border-border/80 px-4 py-2 text-sm font-semibold text-text hover:border-primary hover:text-primary md:hidden"
-                >
-                  PPDB
-                </Link>
-                <MobileNav />
+                  <a
+                    href={waLink("Halo Bu Mintarsih, saya ingin info PPDB TK Kartikasari.")}
+                    className="hidden rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow-soft transition hover:brightness-[1.05] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 md:inline-flex"
+                  >
+                    Chat WhatsApp
+                  </a>
+                  <Link
+                    href="/ppdb"
+                    className="inline-flex items-center rounded-full border border-border/70 px-3 py-2 text-sm font-semibold text-text transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 md:hidden"
+                  >
+                    PPDB
+                  </Link>
+                  <MobileNav />
+                </div>
               </div>
             </div>
           </header>

--- a/tk-kartikasari/components/DesktopNav.tsx
+++ b/tk-kartikasari/components/DesktopNav.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { mainNav } from "@/data/navigation";
+
+export default function DesktopNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav aria-label="Menu utama" className="hidden flex-1 items-center justify-center lg:flex">
+      <ul className="flex items-center gap-1 text-sm font-medium text-text-muted">
+        {mainNav.map((item) => {
+          const isActive =
+            item.href === "/"
+              ? pathname === "/"
+              : pathname === item.href || pathname.startsWith(`${item.href}/`);
+
+          return (
+            <li key={item.href}>
+              <Link
+                href={item.href}
+                aria-current={isActive ? "page" : undefined}
+                className={`rounded-full px-4 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
+                  isActive
+                    ? "bg-primary/10 text-primary"
+                    : "text-text-muted hover:bg-surfaceAlt hover:text-text"
+                }`}
+              >
+                {item.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/tk-kartikasari/components/MobileNav.tsx
+++ b/tk-kartikasari/components/MobileNav.tsx
@@ -14,13 +14,13 @@ export default function MobileNav() {
   const closeMenu = () => setOpen(false);
 
   return (
-    <div className="relative md:hidden">
+    <div className="relative lg:hidden">
       <motion.button
         type="button"
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
         aria-controls="mobile-nav"
-        className="inline-flex items-center justify-center rounded-2xl border border-border/80 bg-white/80 p-2 text-text shadow-soft transition hover:border-primary hover:text-primary"
+        className="inline-flex items-center justify-center rounded-full border border-border/70 bg-white/90 p-2.5 text-text shadow-soft transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
         whileTap={{ scale: 0.95 }}
       >
         <span className="sr-only">Toggle navigation</span>
@@ -46,7 +46,7 @@ export default function MobileNav() {
         {open ? (
           <motion.div
             id="mobile-nav"
-            className="absolute right-0 top-12 z-50 w-64 rounded-3xl border border-border/70 bg-white p-4 shadow-xl"
+            className="absolute right-0 top-14 z-50 w-64 rounded-3xl border border-border/70 bg-white/95 p-4 shadow-xl backdrop-blur"
             initial={{ opacity: 0, y: -8 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -8 }}
@@ -54,13 +54,17 @@ export default function MobileNav() {
           >
             <nav className="flex flex-col gap-1 text-sm font-medium text-text">
               {mainNav.map((item) => {
-                const isActive = pathname === item.href;
+                const isActive =
+                  item.href === "/"
+                    ? pathname === "/"
+                    : pathname === item.href || pathname.startsWith(`${item.href}/`);
                 return (
                   <Link
                     key={item.href}
                     href={item.href}
                     onClick={closeMenu}
-                    className={`rounded-2xl px-4 py-2 transition ${
+                    aria-current={isActive ? "page" : undefined}
+                    className={`rounded-full px-4 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
                       isActive
                         ? "bg-primary/10 text-primary"
                         : "text-text-muted hover:bg-surfaceAlt hover:text-text"


### PR DESCRIPTION
## Summary
- restyle the global header with balanced spacing, focus states, and streamlined call-to-actions
- introduce a dedicated desktop navigation component with active state styling
- tune the mobile navigation trigger and menu to match the updated header design

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d25c32f5f4832f93bcf1a784986d9a