### PR TITLE
Revamp mobile typography and unify layouts

### DIFF
--- a/tk-kartikasari/app/agenda/page.tsx
+++ b/tk-kartikasari/app/agenda/page.tsx
@@ -1,3 +1,5 @@
+import PageHeader from "@/components/layout/PageHeader";
+import PageSection from "@/components/layout/PageSection";
 import agenda from "@/data/agenda.json";
 
 type AgendaItem = (typeof agenda)[number];
@@ -18,46 +20,45 @@ export default function Page() {
   const hasItems = items.length > 0;
 
   return (
-    <div className="container py-8 space-y-6">
-      <header className="space-y-3">
-        <p className="text-sm font-semibold uppercase tracking-wide text-secondary">Agenda</p>
-        <h1 className="text-3xl font-bold sm:text-4xl">Agenda Kegiatan TK Kartikasari</h1>
-        <p className="max-w-2xl text-text-muted">
-          Agenda disusun untuk melibatkan anak dan orang tua dalam pengalaman belajar yang menyenangkan serta penuh kolaborasi.
-          Simpan tanggal penting berikut di kalender keluarga Anda.
-        </p>
-      </header>
+    <>
+      <PageHeader
+        eyebrow="Agenda"
+        title="Agenda Kegiatan TK Kartikasari"
+        description="Agenda disusun untuk melibatkan anak dan orang tua dalam pengalaman belajar yang menyenangkan serta penuh kolaborasi. Simpan tanggal penting berikut di kalender keluarga Anda."
+      />
 
-      {hasItems ? (
-        <ul className="space-y-3">
-          {items.map((item: AgendaItem) => (
-            <li key={item.id} className="card p-5">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <div>
-                  <h2 className="text-xl font-semibold text-text">{item.title}</h2>
-                  <p className="text-sm text-text-muted">{formatDate(item.date)}</p>
+      <PageSection padding="tight">
+        {hasItems ? (
+          <ul className="space-y-4">
+            {items.map((item: AgendaItem) => (
+              <li key={item.id} className="card p-6">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <h2 className="text-2xl font-semibold text-text">{item.title}</h2>
+                    <p className="text-base text-text-muted">{formatDate(item.date)}</p>
+                  </div>
+                  <div className="rounded-2xl bg-secondary/10 px-4 py-2 text-base font-semibold text-secondary">
+                    {item.time}
+                  </div>
                 </div>
-                <div className="rounded-2xl bg-secondary/10 px-4 py-2 text-sm font-semibold text-secondary">
-                  {item.time}
+                <div className="mt-4 space-y-2 text-base text-text-muted">
+                  <p>
+                    <strong className="font-semibold text-text">Lokasi:</strong> {item.location}
+                  </p>
+                  <p>{item.description}</p>
                 </div>
-              </div>
-              <div className="mt-3 space-y-2 text-sm text-text-muted">
-                <p>
-                  <strong className="font-semibold text-text">Lokasi:</strong> {item.location}
-                </p>
-                <p>{item.description}</p>
-              </div>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <div className="card border border-border/70 bg-secondary/5 p-6 text-center">
-          <h2 className="text-lg font-semibold text-text">Belum ada agenda terbaru</h2>
-          <p className="mt-2 text-sm text-text-muted">
-            Kami sedang memperbarui jadwal kegiatan. Silakan cek kembali atau hubungi pihak sekolah untuk informasi terbaru.
-          </p>
-        </div>
-      )}
-    </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="card border border-border/70 bg-secondary/5 p-7 text-center">
+            <h2 className="text-2xl font-semibold text-text">Belum ada agenda terbaru</h2>
+            <p className="mt-3 text-base text-text-muted">
+              Kami sedang memperbarui jadwal kegiatan. Silakan cek kembali atau hubungi pihak sekolah untuk informasi terbaru.
+            </p>
+          </div>
+        )}
+      </PageSection>
+    </>
   );
 }

--- a/tk-kartikasari/app/galeri/page.tsx
+++ b/tk-kartikasari/app/galeri/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import PageHeader from "@/components/layout/PageHeader";
+import PageSection from "@/components/layout/PageSection";
 import data from "@/data/galeri.json";
 
 type GaleriItem = (typeof data)[number];
@@ -8,50 +10,49 @@ export default function Page() {
   const hasPhotos = data.length > 0;
 
   return (
-    <div className="container py-8 space-y-6">
-      <header className="space-y-3">
-        <p className="text-sm font-semibold uppercase tracking-wide text-secondary">Galeri</p>
-        <h1 className="text-3xl font-bold sm:text-4xl">Galeri Kegiatan Anak</h1>
-        <p className="max-w-2xl text-text-muted">
-          Potret kegiatan anak TK Kartikasari dalam suasana belajar yang hangat, aktif, dan menyenangkan. Semua foto dimuat
-          dengan teknik lazy-load agar halaman tetap ringan.
-        </p>
-      </header>
+    <>
+      <PageHeader
+        eyebrow="Galeri"
+        title="Galeri Kegiatan Anak"
+        description="Potret kegiatan anak TK Kartikasari dalam suasana belajar yang hangat, aktif, dan menyenangkan. Semua foto dimuat dengan teknik lazy-load agar halaman tetap ringan."
+      />
 
-      {hasPhotos ? (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {data.map((item: GaleriItem) => (
-            <figure
-              key={item.id}
-              className="overflow-hidden rounded-3xl border border-border/60 bg-white shadow-sm transition hover:shadow-soft"
-            >
-              <img
-                src={item.src}
-                alt={item.alt}
-                loading="lazy"
-                className="h-56 w-full object-cover"
-              />
-              <figcaption className="space-y-1 p-4 text-sm">
-                <p className="font-semibold text-text">{item.caption}</p>
-                <p className="text-xs text-text-muted">{item.alt}</p>
-              </figcaption>
-            </figure>
-          ))}
-        </div>
-      ) : (
-        <div className="card border border-border/70 bg-secondary/5 p-8 text-center">
-          <h2 className="text-xl font-semibold text-text">Dokumentasi segera hadir</h2>
-          <p className="mt-3 text-sm text-text-muted">
-            Tim kami sedang mengkurasi foto kegiatan terbaru agar dapat dibagikan kepada orang tua. Jika Anda membutuhkan
-            informasi tambahan, silakan hubungi kami melalui kanal resmi sekolah.
-          </p>
-          <div className="mt-6 flex justify-center">
-            <Link href="/kontak" className="btn-primary w-full sm:w-auto">
-              Hubungi TK Kartikasari
-            </Link>
+      <PageSection padding="tight">
+        {hasPhotos ? (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {data.map((item: GaleriItem) => (
+              <figure
+                key={item.id}
+                className="overflow-hidden rounded-3xl border border-border/60 bg-white shadow-sm transition hover:shadow-soft"
+              >
+                <img
+                  src={item.src}
+                  alt={item.alt}
+                  loading="lazy"
+                  className="h-56 w-full object-cover"
+                />
+                <figcaption className="space-y-1 p-4 text-base">
+                  <p className="font-semibold text-text">{item.caption}</p>
+                  <p className="text-sm text-text-muted">{item.alt}</p>
+                </figcaption>
+              </figure>
+            ))}
           </div>
-        </div>
-      )}
-    </div>
+        ) : (
+          <div className="card border border-border/70 bg-secondary/5 p-8 text-center">
+            <h2 className="text-2xl font-semibold text-text">Dokumentasi segera hadir</h2>
+            <p className="mt-3 text-base text-text-muted">
+              Tim kami sedang mengkurasi foto kegiatan terbaru agar dapat dibagikan kepada orang tua. Jika Anda membutuhkan
+              informasi tambahan, silakan hubungi kami melalui kanal resmi sekolah.
+            </p>
+            <div className="mt-6 flex justify-center">
+              <Link href="/kontak" className="btn-primary w-full sm:w-auto">
+                Hubungi TK Kartikasari
+              </Link>
+            </div>
+          </div>
+        )}
+      </PageSection>
+    </>
   );
 }

--- a/tk-kartikasari/app/globals.css
+++ b/tk-kartikasari/app/globals.css
@@ -19,8 +19,18 @@ html {
   scroll-behavior: smooth;
 }
 
+:root {
+  font-size: 16px;
+}
+
+@media (max-width: 767px) {
+  :root {
+    font-size: 17px;
+  }
+}
+
 body {
-  @apply bg-surfaceAlt text-text antialiased;
+  @apply bg-surfaceAlt text-text antialiased leading-relaxed;
 }
 
 .container {

--- a/tk-kartikasari/app/kontak/page.tsx
+++ b/tk-kartikasari/app/kontak/page.tsx
@@ -1,7 +1,9 @@
-import site from "@/data/site.json";
-import MapEmbed from "@/components/MapEmbed";
 import CTAButton from "@/components/CTAButton";
+import PageHeader from "@/components/layout/PageHeader";
+import PageSection from "@/components/layout/PageSection";
+import MapEmbed from "@/components/MapEmbed";
 import { contactConsultationCTA } from "@/content/cta";
+import site from "@/data/site.json";
 
 const info = [
   { label: "Alamat", value: site.address },
@@ -12,24 +14,21 @@ const info = [
 
 export default function Page() {
   return (
-    <div className="container py-8 space-y-6">
-      <header className="space-y-3">
-        <p className="text-sm font-semibold uppercase tracking-wide text-secondary">Kontak</p>
-        <h1 className="text-3xl font-bold sm:text-4xl">Hubungi TK Kartikasari</h1>
-        <p className="max-w-2xl text-text-muted">
-          Kami siap membantu informasi seputar PPDB, jadwal kunjungan sekolah, maupun kebutuhan administrasi lainnya. Gunakan
-          detail di bawah ini atau langsung hubungi kami melalui WhatsApp.
-        </p>
-      </header>
+    <>
+      <PageHeader
+        eyebrow="Kontak"
+        title="Hubungi TK Kartikasari"
+        description="Kami siap membantu informasi seputar PPDB, jadwal kunjungan sekolah, maupun kebutuhan administrasi lainnya. Gunakan detail di bawah ini atau langsung hubungi kami melalui WhatsApp."
+      />
 
-      <section className="grid gap-4 md:grid-cols-[1.1fr,0.9fr] md:items-start">
-        <div className="card p-6 space-y-4">
-          <h2 className="text-2xl font-semibold">Informasi Sekolah</h2>
-          <ul className="space-y-3 text-sm text-text">
+      <PageSection padding="tight" containerClassName="grid gap-6 md:grid-cols-[1.1fr,0.9fr] md:items-start">
+        <div className="card space-y-5 p-7">
+          <h2 className="text-3xl font-semibold">Informasi Sekolah</h2>
+          <ul className="space-y-4 text-base text-text">
             {info.map((item) => (
               <li key={item.label}>
                 <p className="text-xs uppercase tracking-wide text-secondary">{item.label}</p>
-                <p className="mt-1 text-base font-medium">{item.value}</p>
+                <p className="mt-1 text-lg font-medium">{item.value}</p>
               </li>
             ))}
           </ul>
@@ -37,8 +36,8 @@ export default function Page() {
             <CTAButton config={contactConsultationCTA} className="w-full sm:w-auto" />
           </div>
         </div>
-        <div className="card p-6 space-y-3 bg-secondary/5 text-sm text-text-muted">
-          <h3 className="text-lg font-semibold text-secondary">Cara Berkunjung</h3>
+        <div className="card space-y-4 bg-secondary/5 p-7 text-base text-text-muted">
+          <h3 className="text-xl font-semibold text-secondary">Cara Berkunjung</h3>
           <p>
             Silakan informasikan kedatangan Anda terlebih dahulu agar kami dapat menyiapkan guru pendamping. Parkir tersedia di
             halaman sekolah dan lingkungan sekitar.
@@ -48,15 +47,17 @@ export default function Page() {
             diperlukan.
           </p>
         </div>
-      </section>
+      </PageSection>
 
-      <section className="space-y-3">
-        <h2 className="text-2xl font-semibold">Lokasi di Peta</h2>
-        <p className="max-w-2xl text-sm text-text-muted">
-          Gunakan peta interaktif berikut untuk menentukan rute terbaik menuju TK Kartikasari di Bulaksari, Cilacap.
-        </p>
+      <PageSection padding="tight" containerClassName="space-y-4">
+        <div>
+          <h2 className="text-3xl font-semibold">Lokasi di Peta</h2>
+          <p className="max-w-2xl text-base text-text-muted">
+            Gunakan peta interaktif berikut untuk menentukan rute terbaik menuju TK Kartikasari di Bulaksari, Cilacap.
+          </p>
+        </div>
         <MapEmbed />
-      </section>
-    </div>
+      </PageSection>
+    </>
   );
 }

--- a/tk-kartikasari/app/layout.tsx
+++ b/tk-kartikasari/app/layout.tsx
@@ -65,16 +65,16 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   <img src={site.logo} alt="Logo TK Kartikasari" className="h-12 w-12 rounded-2xl border border-border/80 bg-surface p-2 shadow-soft" />
                   <div>
                     <p className="text-lg font-semibold">{site.schoolName}</p>
-                    <p className="text-sm text-text-muted">Belajar ceria, tumbuh percaya diri.</p>
+                    <p className="text-base text-text-muted">Belajar ceria, tumbuh percaya diri.</p>
                   </div>
                 </Link>
-                <p className="mt-5 max-w-md text-sm leading-relaxed text-text-muted">
+                <p className="mt-5 max-w-md text-base leading-relaxed text-text-muted">
                   Kami mendampingi anak usia dini untuk mengenal dunia dengan rasa ingin tahu, kemandirian, dan karakter baik dalam lingkungan yang hangat.
                 </p>
               </div>
               <div className="space-y-4">
                 <p className="text-sm font-semibold text-text">Navigasi</p>
-                <ul className="space-y-3 text-sm text-text-muted">
+                <ul className="space-y-3 text-base text-text-muted">
                   <li>
                     <a href="#program" className="transition hover:text-primary">
                       Program Unggulan
@@ -99,7 +99,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               </div>
               <div className="space-y-4">
                 <p className="text-sm font-semibold text-text">Kontak</p>
-                <ul className="space-y-3 text-sm text-text-muted">
+                <ul className="space-y-3 text-base text-text-muted">
                   <li>{site.address}</li>
                   <li>Jam buka: {site.openingHours}</li>
                   <li>

--- a/tk-kartikasari/app/pengumuman/page.tsx
+++ b/tk-kartikasari/app/pengumuman/page.tsx
@@ -1,3 +1,5 @@
+import PageHeader from "@/components/layout/PageHeader";
+import PageSection from "@/components/layout/PageSection";
 import data from "@/data/pengumuman.json";
 
 type Pengumuman = (typeof data)[number];
@@ -20,61 +22,60 @@ export default function Page() {
   );
 
   return (
-    <div className="container py-8 space-y-6">
-      <header className="space-y-3">
-        <p className="text-sm font-semibold uppercase tracking-wide text-secondary">Pengumuman</p>
-        <h1 className="text-3xl font-bold sm:text-4xl">Info Resmi TK Kartikasari</h1>
-        <p className="max-w-2xl text-text-muted">
-          Pantau kabar terbaru terkait PPDB, agenda orang tua, hingga informasi akademik dan libur sekolah. Daftar berikut akan
-          diperbarui secara berkala.
-        </p>
-      </header>
+    <>
+      <PageHeader
+        eyebrow="Pengumuman"
+        title="Info Resmi TK Kartikasari"
+        description="Pantau kabar terbaru terkait PPDB, agenda orang tua, hingga informasi akademik dan libur sekolah. Daftar berikut akan diperbarui secara berkala."
+      />
 
-      {items.length === 0 ? (
-        <div className="card p-6 text-text-muted">
-          Belum ada pengumuman terkini. Silakan kembali beberapa saat lagi atau hubungi sekolah melalui WhatsApp.
-        </div>
-      ) : (
-        <div className="space-y-3">
-          {items.map((item: Pengumuman) => {
-            const external = isExternal(item.url);
-            return (
-              <a
-                key={item.id}
-                href={item.url}
-                target={external ? "_blank" : undefined}
-                rel={external ? "noopener noreferrer" : undefined}
-                className="group block rounded-3xl border border-border/60 bg-white p-5 transition hover:border-secondary hover:shadow-soft"
-              >
-                <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-wide text-secondary">
-                  <span className="rounded-full bg-secondary/10 px-3 py-1 text-secondary">{item.category}</span>
-                  <time dateTime={item.date} className="text-text-muted">
-                    {formatDate(item.date)}
-                  </time>
-                </div>
-                <h2 className="mt-3 text-xl font-semibold text-text">{item.title}</h2>
-                <p className="mt-2 text-sm text-text-muted">{item.excerpt}</p>
-                <span className="mt-3 inline-flex items-center gap-2 text-sm font-semibold text-secondary">
-                  Selengkapnya
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth={1.6}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className="h-4 w-4 transition group-hover:translate-x-1"
-                  >
-                    <path d="M5 12h14" />
-                    <path d="m13 6 6 6-6 6" />
-                  </svg>
-                </span>
-              </a>
-            );
-          })}
-        </div>
-      )}
-    </div>
+      <PageSection padding="tight">
+        {items.length === 0 ? (
+          <div className="card p-7 text-base leading-relaxed text-text-muted">
+            Belum ada pengumuman terkini. Silakan kembali beberapa saat lagi atau hubungi sekolah melalui WhatsApp.
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {items.map((item: Pengumuman) => {
+              const external = isExternal(item.url);
+              return (
+                <a
+                  key={item.id}
+                  href={item.url}
+                  target={external ? "_blank" : undefined}
+                  rel={external ? "noopener noreferrer" : undefined}
+                  className="group block rounded-3xl border border-border/60 bg-white p-6 transition hover:border-secondary hover:shadow-soft"
+                >
+                  <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-wide text-secondary">
+                    <span className="rounded-full bg-secondary/10 px-3 py-1 text-secondary">{item.category}</span>
+                    <time dateTime={item.date} className="text-text-muted">
+                      {formatDate(item.date)}
+                    </time>
+                  </div>
+                  <h2 className="mt-4 text-2xl font-semibold text-text">{item.title}</h2>
+                  <p className="mt-3 text-base text-text-muted">{item.excerpt}</p>
+                  <span className="mt-3 inline-flex items-center gap-2 text-base font-semibold text-secondary">
+                    Selengkapnya
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={1.6}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="h-4 w-4 transition group-hover:translate-x-1"
+                    >
+                      <path d="M5 12h14" />
+                      <path d="m13 6 6 6-6 6" />
+                    </svg>
+                  </span>
+                </a>
+              );
+            })}
+          </div>
+        )}
+      </PageSection>
+    </>
   );
 }

--- a/tk-kartikasari/app/ppdb/page.tsx
+++ b/tk-kartikasari/app/ppdb/page.tsx
@@ -1,4 +1,6 @@
 import CTAButton from "@/components/CTAButton";
+import PageHeader from "@/components/layout/PageHeader";
+import PageSection from "@/components/layout/PageSection";
 import PpdbForm from "@/components/PpdbForm";
 import { ppdbHeadmasterCTA } from "@/content/cta";
 import site from "@/data/site.json";
@@ -35,65 +37,69 @@ const faqs = [
 
 export default function Page() {
   return (
-    <div className="container py-8 space-y-8">
-      <header className="max-w-3xl space-y-3">
-        <p className="text-sm font-semibold uppercase tracking-wide text-secondary">PPDB</p>
-        <h1 className="text-3xl font-bold sm:text-4xl">Penerimaan Peserta Didik Baru</h1>
-        <p className="text-text-muted">
-          Kami menyambut keluarga baru yang ingin bergabung dengan TK Kartikasari. Silakan ikuti alur pendaftaran berikut atau
-          hubungi langsung kepala sekolah melalui WhatsApp.
-        </p>
-      </header>
+    <>
+      <PageHeader
+        eyebrow="PPDB"
+        title="Penerimaan Peserta Didik Baru"
+        description="Kami menyambut keluarga baru yang ingin bergabung dengan TK Kartikasari. Silakan ikuti alur pendaftaran berikut atau hubungi langsung kepala sekolah melalui WhatsApp."
+      />
 
-      <section className="card p-6 space-y-4">
-        <div>
-          <h2 className="text-2xl font-semibold">Cara Pendaftaran</h2>
-          <p className="text-sm text-text-muted">Panduan singkat agar proses pendaftaran berjalan lancar.</p>
+      <PageSection padding="tight">
+        <div className="card space-y-5 p-7">
+          <div>
+            <h2 className="text-3xl font-semibold">Cara Pendaftaran</h2>
+            <p className="text-base text-text-muted">Panduan singkat agar proses pendaftaran berjalan lancar.</p>
+          </div>
+          <ol className="list-decimal space-y-3 pl-5 text-base text-text">
+            {steps.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
+          <div className="pt-2">
+            <CTAButton config={ppdbHeadmasterCTA} />
+          </div>
         </div>
-        <ol className="list-decimal space-y-2 pl-5 text-text">
-          {steps.map((step) => (
-            <li key={step}>{step}</li>
-          ))}
-        </ol>
-        <div className="pt-2">
-          <CTAButton config={ppdbHeadmasterCTA} />
-        </div>
-      </section>
+      </PageSection>
 
-      <section className="card p-6 space-y-5">
-        <div className="space-y-1">
-          <h2 className="text-2xl font-semibold">Formulir Online</h2>
-          <p className="text-sm text-text-muted">
-            Isi data singkat berikut untuk mempercepat proses pendaftaran. Setelah dikirim, WhatsApp akan terbuka otomatis dan
-            tim kami akan menindaklanjuti.
+      <PageSection padding="tight">
+        <div className="card space-y-6 p-7">
+          <div className="space-y-2">
+            <h2 className="text-3xl font-semibold">Formulir Online</h2>
+            <p className="text-base text-text-muted">
+              Isi data singkat berikut untuk mempercepat proses pendaftaran. Setelah dikirim, WhatsApp akan terbuka otomatis dan
+              tim kami akan menindaklanjuti.
+            </p>
+          </div>
+          <PpdbForm />
+          <p className="text-xs text-text-muted">
+            Data yang terkirim bersifat rahasia dan hanya digunakan untuk keperluan administrasi PPDB TK Kartikasari.
           </p>
         </div>
-        <PpdbForm />
-        <p className="text-xs text-text-muted">
-          Data yang terkirim bersifat rahasia dan hanya digunakan untuk keperluan administrasi PPDB TK Kartikasari.
-        </p>
-      </section>
+      </PageSection>
 
-      <section className="card p-6 space-y-4">
-        <h2 className="text-2xl font-semibold">FAQ Pendaftaran</h2>
-        <div className="space-y-3">
-          {faqs.map((item) => (
-            <details key={item.question} className="group rounded-2xl border border-border/70 bg-white p-4">
-              <summary className="cursor-pointer text-base font-semibold text-text">
-                {item.question}
-              </summary>
-              <p className="mt-2 text-sm text-text-muted">{item.answer}</p>
-            </details>
-          ))}
+      <PageSection padding="tight">
+        <div className="card space-y-5 p-7">
+          <h2 className="text-3xl font-semibold">FAQ Pendaftaran</h2>
+          <div className="space-y-3">
+            {faqs.map((item) => (
+              <details key={item.question} className="group rounded-2xl border border-border/70 bg-white p-5">
+                <summary className="cursor-pointer text-lg font-semibold text-text">
+                  {item.question}
+                </summary>
+                <p className="mt-2 text-base text-text-muted">{item.answer}</p>
+              </details>
+            ))}
+          </div>
         </div>
-      </section>
+      </PageSection>
 
-      <footer className="rounded-3xl border border-dashed border-secondary/60 bg-secondary/10 p-6 text-sm text-secondary">
-        <p>
-          Alamat sekolah: {site.address}. Kami buka hari {site.openingHours}. Silakan hubungi {site.headmaster} melalui WhatsApp{" "}
-          {site.whatsapp} untuk menjadwalkan kunjungan.
-        </p>
-      </footer>
-    </div>
+      <PageSection padding="tight">
+        <footer className="rounded-3xl border border-dashed border-secondary/60 bg-secondary/10 p-7 text-base text-secondary">
+          <p>
+            Alamat sekolah: {site.address}. Kami buka hari {site.openingHours}. Silakan hubungi {site.headmaster} melalui WhatsApp {site.whatsapp} untuk menjadwalkan kunjungan.
+          </p>
+        </footer>
+      </PageSection>
+    </>
   );
 }

--- a/tk-kartikasari/app/program/page.tsx
+++ b/tk-kartikasari/app/program/page.tsx
@@ -1,3 +1,6 @@
+import PageHeader from "@/components/layout/PageHeader";
+import PageSection from "@/components/layout/PageSection";
+
 const classes = [
   {
     name: "Kelas A • Bintang Kecil",
@@ -76,60 +79,63 @@ const weeklySchedule = [
 
 export default function Page() {
   return (
-    <div className="container py-8 space-y-10">
-      <header className="max-w-3xl space-y-3">
-        <p className="text-sm font-semibold uppercase tracking-wide text-secondary">Program Pembelajaran</p>
-        <h1 className="text-3xl font-bold sm:text-4xl">Program & Kegiatan TK Kartikasari</h1>
-        <p className="text-text-muted">
-          Program dirancang untuk menstimulasi seluruh aspek perkembangan anak usia dini dengan pendekatan bermain yang bermakna
-          dan dukungan kolaboratif antara guru serta orang tua.
-        </p>
-      </header>
+    <>
+      <PageHeader
+        eyebrow="Program Pembelajaran"
+        title="Program & Kegiatan TK Kartikasari"
+        description="Program dirancang untuk menstimulasi seluruh aspek perkembangan anak usia dini dengan pendekatan bermain yang bermakna dan dukungan kolaboratif antara guru serta orang tua."
+      />
 
-      <section className="grid gap-4 lg:grid-cols-2">
+      <PageSection padding="tight" containerClassName="grid gap-6 lg:grid-cols-2">
         {classes.map((item) => (
-          <article key={item.name} className="card p-6 space-y-4">
+          <article key={item.name} className="card space-y-4 p-7">
             <div>
-              <h2 className="text-2xl font-semibold">{item.name}</h2>
-              <p className="text-sm text-text-muted">{item.age}</p>
+              <h2 className="text-3xl font-semibold">{item.name}</h2>
+              <p className="text-base text-text-muted">{item.age}</p>
             </div>
-            <p className="text-text-muted">{item.description}</p>
-            <ul className="list-disc space-y-2 pl-5 text-sm text-text">
+            <p className="text-pretty text-base leading-relaxed text-text-muted">{item.description}</p>
+            <ul className="list-disc space-y-2 pl-5 text-base text-text">
               {item.focus.map((point) => (
                 <li key={point}>{point}</li>
               ))}
             </ul>
           </article>
         ))}
-      </section>
+      </PageSection>
 
-      <section className="card p-6 space-y-5">
-        <h2 className="text-2xl font-semibold">Metode Belajar</h2>
-        <div className="grid gap-4 md:grid-cols-2">
-          {learningMethods.map((method) => (
-            <div key={method.title} className="rounded-2xl border border-border/60 bg-white p-5">
-              <h3 className="text-lg font-semibold text-secondary">{method.title}</h3>
-              <p className="mt-2 text-sm text-text-muted">{method.description}</p>
-            </div>
-          ))}
+      <PageSection padding="tight">
+        <div className="card space-y-6 p-7">
+          <h2 className="text-3xl font-semibold">Metode Belajar</h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            {learningMethods.map((method) => (
+              <div key={method.title} className="rounded-2xl border border-border/60 bg-white p-6">
+                <h3 className="text-xl font-semibold text-secondary">{method.title}</h3>
+                <p className="mt-2 text-base text-text-muted">{method.description}</p>
+              </div>
+            ))}
+          </div>
         </div>
-      </section>
+      </PageSection>
 
-      <section className="card p-6 space-y-4">
-        <div>
-          <h2 className="text-2xl font-semibold">Jadwal Mingguan</h2>
-          <p className="text-sm text-text-muted">Jadwal fleksibel mengikuti tema, namun pola rutinitas berikut membantu anak merasa aman.</p>
+      <PageSection padding="tight">
+        <div className="card space-y-5 p-7">
+          <div>
+            <h2 className="text-3xl font-semibold">Jadwal Mingguan</h2>
+            <p className="text-base text-text-muted">
+              Jadwal fleksibel mengikuti tema, namun pola rutinitas berikut membantu anak merasa aman.
+            </p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {weeklySchedule.map((item) => (
+              <div key={item.day} className="rounded-2xl border border-border/60 bg-secondary/5 p-5">
+                <p className="text-xs font-semibold uppercase tracking-wide text-secondary">{item.day}</p>
+                <p className="mt-1 text-lg font-semibold text-text">{item.theme}</p>
+                <p className="mt-2 text-base text-text-muted">{item.highlight}</p>
+              </div>
+            ))}
+          </div>
         </div>
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {weeklySchedule.map((item) => (
-            <div key={item.day} className="rounded-2xl border border-border/60 bg-secondary/5 p-4">
-              <p className="text-xs font-semibold uppercase tracking-wide text-secondary">{item.day}</p>
-              <p className="mt-1 text-base font-semibold text-text">{item.theme}</p>
-              <p className="mt-2 text-sm text-text-muted">{item.highlight}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-    </div>
+      </PageSection>
+    </>
   );
 }

--- a/tk-kartikasari/app/tentang/page.tsx
+++ b/tk-kartikasari/app/tentang/page.tsx
@@ -1,3 +1,5 @@
+import PageHeader from "@/components/layout/PageHeader";
+import PageSection from "@/components/layout/PageSection";
 import site from "@/data/site.json";
 
 const profileItems = [
@@ -18,75 +20,83 @@ const mission = [
 
 export default function Page() {
   return (
-    <div className="container py-8 space-y-8">
-      <header className="max-w-3xl space-y-3">
-        <p className="text-sm font-semibold uppercase tracking-wide text-secondary">Tentang Sekolah</p>
-        <h1 className="text-3xl font-bold sm:text-4xl">TK Kartikasari</h1>
-        <p className="text-text-muted">
-          TK Kartikasari hadir sebagai lingkungan bermain-belajar yang hangat bagi anak usia dini di Bantarsari, Cilacap.
-          Kami berfokus pada stimulasi kemandirian, kreativitas, dan karakter melalui kegiatan tematik yang menyenangkan.
-        </p>
-      </header>
+    <>
+      <PageHeader
+        eyebrow="Tentang Sekolah"
+        title="TK Kartikasari"
+        description={
+          <>
+            TK Kartikasari hadir sebagai lingkungan bermain-belajar yang hangat bagi anak usia dini di Bantarsari, Cilacap.
+            Kami berfokus pada stimulasi kemandirian, kreativitas, dan karakter melalui kegiatan tematik yang menyenangkan.
+          </>
+        }
+      />
 
-      <section id="sambutan" className="card p-6 space-y-4">
-        <div>
-          <h2 className="text-2xl font-semibold">Sambutan Kepala Sekolah</h2>
-          <p className="text-sm text-text-muted">Ibu Mintarsih, Kepala TK Kartikasari</p>
+      <PageSection id="sambutan" padding="tight" containerClassName="max-w-4xl">
+        <div className="card space-y-5 p-8">
+          <div>
+            <h2 className="text-3xl font-semibold">Sambutan Kepala Sekolah</h2>
+            <p className="text-base text-text-muted">Ibu Mintarsih, Kepala TK Kartikasari</p>
+          </div>
+          <p className="text-pretty text-base leading-relaxed text-text">
+            Selamat datang di TK Kartikasari. Kami percaya setiap anak adalah pribadi unik yang layak mendapatkan perhatian
+            dan stimulasi yang tepat. Tim pengajar kami hadir untuk menumbuhkan rasa ingin tahu, kreativitas, dan kemandirian
+            dalam suasana belajar yang hangat dan aman. Kami mendorong komunikasi harian antara orang tua dan guru agar
+            perkembangan anak terpantau dengan baik. Setiap hari di TK Kartikasari adalah kesempatan untuk bermain,
+            bereksplorasi, dan bertumbuh bersama.
+          </p>
         </div>
-        <p className="leading-relaxed text-text">
-          Selamat datang di TK Kartikasari. Kami percaya setiap anak adalah pribadi unik yang layak mendapatkan perhatian dan
-          stimulasi yang tepat. Tim pengajar kami hadir untuk menumbuhkan rasa ingin tahu, kreativitas, dan kemandirian dalam
-          suasana belajar yang hangat dan aman. Kami mendorong komunikasi harian antara orang tua dan guru agar perkembangan
-          anak terpantau dengan baik. Setiap hari di TK Kartikasari adalah kesempatan untuk bermain, bereksplorasi, dan
-          bertumbuh bersama.
-        </p>
-      </section>
+      </PageSection>
 
-      <section id="profil" className="grid gap-4 md:grid-cols-[1.2fr,0.8fr] md:items-start">
-        <div className="card p-6 space-y-4">
-          <h2 className="text-2xl font-semibold">Profil Sekolah</h2>
-          <p className="text-text-muted">
+      <PageSection
+        id="profil"
+        padding="tight"
+        containerClassName="grid gap-6 md:grid-cols-[1.2fr,0.8fr] md:items-start"
+      >
+        <div className="card space-y-5 p-7">
+          <h2 className="text-3xl font-semibold">Profil Sekolah</h2>
+          <p className="text-pretty text-base leading-relaxed text-text-muted">
             Kami melayani anak usia 4–6 tahun dengan pendekatan belajar aktif. Lingkungan sekolah dibuat aman dan nyaman
             sehingga anak bebas mengekspresikan diri sambil dibimbing guru berpengalaman.
           </p>
           <ul className="grid gap-4 sm:grid-cols-2">
             {profileItems.map((item) => (
-              <li key={item.label} className="rounded-2xl border border-border bg-white p-4">
+              <li key={item.label} className="rounded-2xl border border-border bg-white p-5">
                 <p className="text-xs uppercase tracking-wide text-secondary">{item.label}</p>
-                <p className="mt-1 text-sm font-medium text-text">{item.value}</p>
+                <p className="mt-1 text-base font-medium text-text">{item.value}</p>
               </li>
             ))}
           </ul>
         </div>
-        <div className="card p-6 space-y-3 bg-secondary/5">
-          <h3 className="text-lg font-semibold text-secondary">Pendekatan Kami</h3>
-          <p className="text-sm text-text-muted">
+        <div className="card space-y-4 bg-secondary/5 p-7">
+          <h3 className="text-xl font-semibold text-secondary">Pendekatan Kami</h3>
+          <p className="text-base text-text-muted">
             Guru dan orang tua membangun komunikasi rutin melalui laporan harian. Aktivitas dipadukan dengan nilai moral,
             pembiasaan ibadah, dan kerja sama kelompok kecil agar setiap anak merasa dihargai.
           </p>
-          <p className="text-sm text-text-muted">
+          <p className="text-base text-text-muted">
             Fasilitas meliputi ruang kelas tematik, area bermain outdoor, dan sentra seni yang mendukung eksplorasi anak.
           </p>
         </div>
-      </section>
+      </PageSection>
 
-      <section id="visi-misi" className="grid gap-4 md:grid-cols-2">
-        <div className="card p-6">
-          <h2 className="text-2xl font-semibold">Visi</h2>
-          <p className="mt-3 text-text-muted">
+      <PageSection id="visi-misi" padding="tight" containerClassName="grid gap-6 md:grid-cols-2">
+        <div className="card space-y-3 p-7">
+          <h2 className="text-3xl font-semibold">Visi</h2>
+          <p className="text-pretty text-base leading-relaxed text-text-muted">
             Menjadi taman kanak-kanak yang hangat, aman, dan inspiratif, yang menumbuhkan kemandirian, kreativitas, serta
             karakter anak sebagai fondasi pendidikan masa depan.
           </p>
         </div>
-        <div className="card p-6">
-          <h2 className="text-2xl font-semibold">Misi</h2>
-          <ul className="mt-3 list-disc space-y-2 pl-5 text-text-muted">
+        <div className="card space-y-3 p-7">
+          <h2 className="text-3xl font-semibold">Misi</h2>
+          <ul className="mt-1 list-disc space-y-2 pl-5 text-base leading-relaxed text-text-muted">
             {mission.map((point) => (
               <li key={point}>{point}</li>
             ))}
           </ul>
         </div>
-      </section>
-    </div>
+      </PageSection>
+    </>
   );
 }

--- a/tk-kartikasari/components/DesktopNav.tsx
+++ b/tk-kartikasari/components/DesktopNav.tsx
@@ -10,7 +10,7 @@ export default function DesktopNav() {
 
   return (
     <nav aria-label="Menu utama" className="hidden flex-1 items-center justify-center lg:flex">
-      <ul className="flex items-center gap-1 text-sm font-medium text-text-muted">
+      <ul className="flex items-center gap-1 text-base font-medium text-text-muted">
         {mainNav.map((item) => {
           const isActive =
             item.href === "/"

--- a/tk-kartikasari/components/MobileNav.tsx
+++ b/tk-kartikasari/components/MobileNav.tsx
@@ -52,7 +52,7 @@ export default function MobileNav() {
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.2, ease: "easeOut" }}
           >
-            <nav className="flex flex-col gap-1 text-sm font-medium text-text">
+            <nav className="flex flex-col gap-1 text-base font-medium text-text">
               {mainNav.map((item) => {
                 const isActive =
                   item.href === "/"

--- a/tk-kartikasari/components/StickyActions.tsx
+++ b/tk-kartikasari/components/StickyActions.tsx
@@ -10,8 +10,8 @@ export default function StickyActions() {
       <div className="container pointer-events-auto">
         <div className="flex flex-col gap-4 rounded-3xl border border-border/70 bg-surface/95 px-5 py-5 shadow-soft backdrop-blur sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="text-sm font-semibold text-primary">Siap membantu orang tua baru</p>
-            <p className="text-sm text-text-muted sm:text-base">
+            <p className="text-base font-semibold text-primary">Siap membantu orang tua baru</p>
+            <p className="text-base text-text-muted sm:text-lg">
               Hubungi Bu Mintarsih atau dapatkan petunjuk arah menuju sekolah kami.
             </p>
           </div>

--- a/tk-kartikasari/components/TestimonialList.tsx
+++ b/tk-kartikasari/components/TestimonialList.tsx
@@ -1,49 +1,55 @@
 "use client";
 
-import data from "@/data/testimonials.json";
 import { LazyMotion, domAnimation, m } from "framer-motion";
+
+import PageSection from "@/components/layout/PageSection";
+import SectionHeader from "@/components/layout/SectionHeader";
+import data from "@/data/testimonials.json";
 
 export default function TestimonialList() {
   if (data.length === 0) {
     return (
-      <section id="testimonials" className="py-20">
-        <div className="container">
-          <div className="card mx-auto max-w-3xl border border-border/70 bg-secondary/5 p-8 text-center text-text-muted">
-            <h2 className="text-2xl font-semibold text-text">Testimoni segera hadir</h2>
-            <p className="mt-3 text-sm">
-              Kami sedang menghimpun cerita terbaru dari orang tua murid. Kembali lagi nanti untuk membaca pengalaman mereka
-              bersama TK Kartikasari.
-            </p>
-          </div>
+      <PageSection id="testimonials" padding="relaxed">
+        <div className="card mx-auto max-w-3xl border border-border/70 bg-secondary/5 p-8 text-center text-text-muted">
+          <h2 className="text-3xl font-semibold text-text">Testimoni segera hadir</h2>
+          <p className="mt-4 text-base">
+            Kami sedang menghimpun cerita terbaru dari orang tua murid. Kembali lagi nanti untuk membaca pengalaman mereka
+            bersama TK Kartikasari.
+          </p>
         </div>
-      </section>
+      </PageSection>
     );
   }
 
   return (
     <LazyMotion features={domAnimation}>
-      <section id="testimonials" className="relative overflow-hidden py-20">
+      <PageSection
+        id="testimonials"
+        className="relative overflow-hidden"
+        padding="relaxed"
+      >
         <div className="absolute inset-x-0 top-10 flex justify-center">
           <div className="h-48 w-48 rounded-full bg-secondary/20 blur-3xl sm:h-72 sm:w-72" />
         </div>
-        <div className="container relative">
+        <div className="relative">
           <m.div
             initial={{ opacity: 0, y: 30 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true, amount: 0.4 }}
             transition={{ duration: 0.6 }}
-            className="mx-auto max-w-2xl text-center"
           >
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/40 bg-white/80 px-4 py-2 text-sm font-semibold text-secondary shadow-soft">
-              <span className="h-2.5 w-2.5 rounded-full bg-secondary" />
-              Suara Orang Tua
-            </span>
-            <h2 className="mt-4 text-3xl font-bold leading-tight text-text sm:text-4xl">
-              Mereka melihat anak tumbuh lebih percaya diri dan bahagia
-            </h2>
-            <p className="mt-3 text-lg text-text-muted">
-              Cerita asli dari keluarga yang mempercayakan proses belajar anaknya di TK Kartikasari.
-            </p>
+            <SectionHeader
+              align="center"
+              eyebrow={
+                <span className="flex items-center gap-2">
+                  <span className="h-2.5 w-2.5 rounded-full bg-secondary" />
+                  Suara Orang Tua
+                </span>
+              }
+              eyebrowVariant="secondary"
+              title="Mereka melihat anak tumbuh lebih percaya diri dan bahagia"
+              description="Cerita asli dari keluarga yang mempercayakan proses belajar anaknya di TK Kartikasari."
+            />
           </m.div>
 
           <div className="mt-14 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
@@ -64,13 +70,13 @@ export default function TestimonialList() {
                     ))}
                   </div>
                   <p className="text-lg font-medium leading-relaxed text-text">“{t.quote}”</p>
-                  <p className="text-sm font-semibold text-text/80">{t.author}</p>
+                  <p className="text-base font-semibold text-text/80">{t.author}</p>
                 </div>
               </m.blockquote>
             ))}
           </div>
         </div>
-      </section>
+      </PageSection>
     </LazyMotion>
   );
 }

--- a/tk-kartikasari/components/home/HomePageContent.tsx
+++ b/tk-kartikasari/components/home/HomePageContent.tsx
@@ -3,6 +3,8 @@
 import CTAButton from "@/components/CTAButton";
 import StickyActions from "@/components/StickyActions";
 import TestimonialList from "@/components/TestimonialList";
+import PageSection from "@/components/layout/PageSection";
+import SectionHeader from "@/components/layout/SectionHeader";
 import type { CTAConfig } from "@/content/cta";
 import { LazyMotion, domAnimation, m } from "framer-motion";
 
@@ -62,356 +64,351 @@ export default function HomePageContent({
   return (
     <LazyMotion features={domAnimation}>
       <>
-        <section className="relative overflow-hidden pt-16">
+        <PageSection
+          className="relative overflow-hidden"
+          padding="none"
+          containerClassName="relative grid gap-16 pb-24 pt-20 md:grid-cols-[1.05fr,0.95fr] md:items-center"
+        >
           <div className="pointer-events-none absolute inset-0">
             <div className="absolute -top-32 right-16 h-72 w-72 rounded-full bg-secondary/20 blur-3xl" />
             <div className="absolute -left-32 top-24 h-80 w-80 rounded-full bg-primary/25 blur-3xl" />
             <div className="absolute inset-x-0 bottom-0 h-1/2 bg-hero-gradient" />
           </div>
-          <div className="container relative grid gap-16 pb-24 pt-12 md:grid-cols-[1.05fr,0.95fr] md:items-center">
-            <m.div
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              className="space-y-8"
-            >
-              <span className="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/80 px-4 py-2 text-sm font-semibold text-secondary shadow-soft">
-                <span className="h-2.5 w-2.5 rounded-full bg-secondary" />
-                {schoolName} • Bulaksari
-              </span>
-              <h1 className="text-4xl font-bold leading-tight text-text sm:text-5xl">
-                Belajar ceria, tumbuh percaya diri bersama sahabat baru setiap hari
-              </h1>
-              <p className="max-w-xl text-lg leading-relaxed text-text-muted">
-                Lingkungan hangat, fasilitas aman, dan kegiatan tematik yang menumbuhkan rasa ingin tahu anak usia dini di Bantarsari, Cilacap.
-              </p>
-              <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
-                <CTAButton config={heroCta} className="w-full sm:w-auto" />
-                <a href="#program" className="btn-outline w-full sm:w-auto">
-                  Lihat program unggulan
-                </a>
-              </div>
-              <dl className="grid gap-6 pt-6 sm:grid-cols-2 md:grid-cols-3">
-                {stats.map((item) => (
-                  <div
-                    key={item.label}
-                    className="rounded-3xl border border-white/60 bg-white/80 p-5 text-left shadow-soft"
-                  >
-                    <dt className="text-3xl font-bold text-text">{item.value}</dt>
-                    <dd className="mt-1 text-sm text-text-muted">{item.label}</dd>
-                  </div>
-                ))}
-              </dl>
-            </m.div>
-
-            <m.div
-              initial={{ opacity: 0, y: 60 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.7, delay: 0.1 }}
-              className="relative"
-            >
-              <div className="absolute -top-12 right-10 h-32 w-32 rounded-full bg-accent/40 blur-2xl" />
-              <div className="absolute -bottom-4 left-0 h-28 w-28 rounded-full bg-secondary/30 blur-2xl md:-bottom-8" />
-              <div className="relative space-y-5">
-                <div className="card overflow-hidden border-white/60 bg-white/90 p-6 shadow-soft">
-                  <div className="flex items-center justify-between text-sm font-semibold text-text">
-                    <span>Agenda Hari Ini</span>
-                    <span className="rounded-full bg-secondary/10 px-3 py-1 text-secondary">
-                      Tema Pelangi
-                    </span>
-                  </div>
-                  <ul className="mt-4 space-y-3 text-sm text-text-muted">
-                    <li className="flex items-start gap-3">
-                      <span className="mt-0.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-sm">
-                        07.00
-                      </span>
-                      Sambutan pagi & permainan pemanasan
-                    </li>
-                    <li className="flex items-start gap-3">
-                      <span className="mt-0.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-sm">
-                        08.30
-                      </span>
-                      Eksperimen warna di laboratorium mini
-                    </li>
-                    <li className="flex items-start gap-3">
-                      <span className="mt-0.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-sm">
-                        10.00
-                      </span>
-                      Bermain air & pasir di taman sensori
-                    </li>
-                  </ul>
-                </div>
-                <div className="ml-auto w-[85%] rounded-3xl border border-white/60 bg-white/70 p-6 shadow-soft backdrop-blur">
-                  <p className="text-sm font-semibold text-secondary">Lingkungan Aman</p>
-                  <p className="mt-3 text-sm leading-relaxed text-text-muted">
-                    Semua area belajar dipantau CCTV, dilengkapi akses kontrol, serta peralatan ramah anak.
-                  </p>
-                  <div className="mt-4 flex items-center gap-3 text-sm font-semibold text-text">
-                    <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/15 text-lg">
-                      😊
-                    </span>
-                    Rasio guru : murid 1 : 8
-                  </div>
-                </div>
-                <div className="grid gap-4 sm:grid-cols-2">
-                  <div className="rounded-3xl border border-white/60 bg-white/90 p-5 shadow-soft">
-                    <p className="text-sm font-semibold text-secondary">Fokus Harian</p>
-                    <p className="mt-2 text-sm text-text-muted">
-                      Motorik, bahasa, sosial-emosi, dan kemandirian.
-                    </p>
-                  </div>
-                  <div className="rounded-3xl border border-white/60 bg-white/90 p-5 shadow-soft">
-                    <p className="text-sm font-semibold text-secondary">Menu Sehat</p>
-                    <p className="mt-2 text-sm text-text-muted">
-                      Snack buah segar & susu rendah gula.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </m.div>
-          </div>
-        </section>
-
-        <section className="relative border-y border-white/60 bg-white/80 py-12 md:py-20">
-          <div className="container">
-            <m.div
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, amount: 0.4 }}
-              transition={{ duration: 0.6 }}
-              className="mx-auto max-w-2xl text-center"
-            >
-              <span className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 text-sm font-semibold text-primary">
-                Mengapa orang tua memilih kami
-              </span>
-              <h2 className="mt-4 text-3xl font-bold leading-tight text-text sm:text-4xl">
-                Sekolah yang menumbuhkan rasa ingin tahu dan karakter positif sejak dini
-              </h2>
-              <p className="mt-3 text-lg text-text-muted">
-                Tim pengajar kami merancang pengalaman belajar yang menyeluruh, menyenangkan, dan penuh perhatian.
-              </p>
-            </m.div>
-            <div className="mt-12 grid gap-6 md:grid-cols-3">
-              {highlights.map((item, index) => (
-                <m.div
-                  key={item.title}
-                  initial={{ opacity: 0, y: 40 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true, amount: 0.3 }}
-                  transition={{ duration: 0.55, delay: index * 0.08 }}
-                  className="card h-full border-white/60 bg-white/90 p-7 text-left"
+          <m.div
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6 }}
+            className="relative space-y-8"
+          >
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/80 px-4 py-2 text-sm font-semibold text-secondary shadow-soft">
+              <span className="h-2.5 w-2.5 rounded-full bg-secondary" />
+              {schoolName} • Bulaksari
+            </span>
+            <h1 className="text-balance text-4xl font-bold leading-tight text-text sm:text-5xl">
+              Belajar ceria, tumbuh percaya diri bersama sahabat baru setiap hari
+            </h1>
+            <p className="max-w-xl text-pretty text-lg text-text-muted sm:text-xl">
+              Lingkungan hangat, fasilitas aman, dan kegiatan tematik yang menumbuhkan rasa ingin tahu anak usia dini di Bantarsari, Cilacap.
+            </p>
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+              <CTAButton config={heroCta} className="w-full sm:w-auto" />
+              <a href="#program" className="btn-outline w-full sm:w-auto">
+                Lihat program unggulan
+              </a>
+            </div>
+            <dl className="grid gap-6 pt-6 sm:grid-cols-2 md:grid-cols-3">
+              {stats.map((item) => (
+                <div
+                  key={item.label}
+                  className="rounded-3xl border border-white/60 bg-white/80 p-5 text-left shadow-soft"
                 >
-                  <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/15 text-2xl">
+                  <dt className="text-3xl font-bold text-text">{item.value}</dt>
+                  <dd className="mt-1 text-base text-text-muted">{item.label}</dd>
+                </div>
+              ))}
+            </dl>
+          </m.div>
+
+          <m.div
+            initial={{ opacity: 0, y: 60 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, delay: 0.1 }}
+            className="relative"
+          >
+            <div className="absolute -top-12 right-10 h-32 w-32 rounded-full bg-accent/40 blur-2xl" />
+            <div className="absolute -bottom-4 left-0 h-28 w-28 rounded-full bg-secondary/30 blur-2xl md:-bottom-8" />
+            <div className="relative space-y-5">
+              <div className="card overflow-hidden border-white/60 bg-white/90 p-6 shadow-soft">
+                <div className="flex items-center justify-between text-base font-semibold text-text">
+                  <span>Agenda Hari Ini</span>
+                  <span className="rounded-full bg-secondary/10 px-3 py-1 text-sm font-semibold text-secondary">
+                    Tema Pelangi
+                  </span>
+                </div>
+                <ul className="mt-4 space-y-3 text-base text-text-muted">
+                  <li className="flex items-start gap-3">
+                    <span className="mt-0.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold">
+                      07.00
+                    </span>
+                    Sambutan pagi & permainan pemanasan
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <span className="mt-0.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold">
+                      08.30
+                    </span>
+                    Eksperimen warna di laboratorium mini
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <span className="mt-0.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold">
+                      10.00
+                    </span>
+                    Bermain air & pasir di taman sensori
+                  </li>
+                </ul>
+              </div>
+              <div className="ml-auto w-[85%] rounded-3xl border border-white/60 bg-white/70 p-6 shadow-soft backdrop-blur">
+                <p className="text-base font-semibold text-secondary">Lingkungan Aman</p>
+                <p className="mt-3 text-base leading-relaxed text-text-muted">
+                  Semua area belajar dipantau CCTV, dilengkapi akses kontrol, serta peralatan ramah anak.
+                </p>
+                <div className="mt-4 flex items-center gap-3 text-base font-semibold text-text">
+                  <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/15 text-lg">
+                    😊
+                  </span>
+                  Rasio guru : murid 1 : 8
+                </div>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="rounded-3xl border border-white/60 bg-white/90 p-5 shadow-soft">
+                  <p className="text-base font-semibold text-secondary">Fokus Harian</p>
+                  <p className="mt-2 text-base text-text-muted">
+                    Motorik, bahasa, sosial-emosi, dan kemandirian.
+                  </p>
+                </div>
+                <div className="rounded-3xl border border-white/60 bg-white/90 p-5 shadow-soft">
+                  <p className="text-base font-semibold text-secondary">Menu Sehat</p>
+                  <p className="mt-2 text-base text-text-muted">
+                    Snack buah segar & susu rendah gula.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </m.div>
+        </PageSection>
+
+        <PageSection
+          className="relative border-y border-white/60 bg-white/80"
+          padding="tight"
+        >
+          <m.div
+            initial={{ opacity: 0, y: 30 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.4 }}
+            transition={{ duration: 0.6 }}
+          >
+            <SectionHeader
+              align="center"
+              eyebrow="Mengapa orang tua memilih kami"
+              eyebrowVariant="primary"
+              description="Tim pengajar kami merancang pengalaman belajar yang menyeluruh, menyenangkan, dan penuh perhatian."
+              title="Sekolah yang menumbuhkan rasa ingin tahu dan karakter positif sejak dini"
+            />
+          </m.div>
+          <div className="mt-12 grid gap-6 md:grid-cols-3">
+            {highlights.map((item, index) => (
+              <m.div
+                key={item.title}
+                initial={{ opacity: 0, y: 40 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, amount: 0.3 }}
+                transition={{ duration: 0.55, delay: index * 0.08 }}
+                className="card h-full border-white/60 bg-white/90 p-7 text-left"
+              >
+                <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/15 text-2xl">
+                  {item.icon}
+                </span>
+                <h3 className="mt-6 text-xl font-semibold text-text">{item.title}</h3>
+                <p className="mt-3 text-base leading-relaxed text-text-muted">{item.description}</p>
+              </m.div>
+            ))}
+          </div>
+        </PageSection>
+
+        <PageSection
+          id="program"
+          padding="tight"
+          containerClassName="grid gap-12 lg:grid-cols-[1fr,1fr] lg:items-start"
+        >
+          <m.div
+            initial={{ opacity: 0, y: 40 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.4 }}
+            transition={{ duration: 0.6 }}
+            className="space-y-6"
+          >
+            <SectionHeader
+              eyebrow="Program unggulan"
+              eyebrowVariant="secondary"
+              title="Tiga jalur belajar yang disesuaikan dengan tahap tumbuh kembang anak"
+              description="Setiap kelas dipandu guru inti dan guru pendamping dengan rasio kecil. Kami menyeimbangkan stimulasi akademik, karakter, dan kegiatan bermain bebas."
+            />
+            <ul className="space-y-3 text-base text-text-muted">
+              <li className="flex items-start gap-3">
+                <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">
+                  1
+                </span>
+                Observasi minat dan kebutuhan anak sebelum penempatan kelas.
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">
+                  2
+                </span>
+                Rencana belajar individual yang dikirim ke orang tua di awal tema.
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">
+                  3
+                </span>
+                Evaluasi menyenangkan melalui pameran karya dan pertunjukan kecil.
+              </li>
+            </ul>
+          </m.div>
+          <div className="grid gap-6">
+            {programs.map((program, index) => (
+              <m.div
+                key={program.name}
+                initial={{ opacity: 0, y: 40 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, amount: 0.3 }}
+                transition={{ duration: 0.55, delay: index * 0.08 }}
+                className="card h-full border-white/70 bg-white/90 p-7 shadow-soft"
+              >
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="space-y-3">
+                    <p className="text-sm font-semibold uppercase tracking-wide text-secondary">
+                      {program.age}
+                    </p>
+                    <h3 className="text-2xl font-semibold text-text">{program.name}</h3>
+                    <p className="text-base leading-relaxed text-text-muted">
+                      {program.description}
+                    </p>
+                  </div>
+                  <span className="inline-flex h-12 min-w-[3rem] items-center justify-center rounded-2xl bg-primary/15 text-2xl">
+                    ✨
+                  </span>
+                </div>
+                <ul className="mt-6 space-y-2 text-base text-text-muted">
+                  {program.points.map((point) => (
+                    <li key={point} className="flex items-start gap-3">
+                      <span className="mt-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-secondary/10 text-xs font-semibold text-secondary">
+                        ✓
+                      </span>
+                      {point}
+                    </li>
+                  ))}
+                </ul>
+              </m.div>
+            ))}
+          </div>
+        </PageSection>
+
+        <PageSection
+          id="pengalaman"
+          className="relative overflow-hidden"
+          padding="tight"
+          containerClassName="relative grid gap-12 lg:grid-cols-[0.9fr,1.1fr] lg:items-center"
+        >
+          <div className="absolute inset-0 bg-grid-dots [background-size:24px_24px] opacity-40" />
+          <m.div
+            initial={{ opacity: 0, y: 40 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.4 }}
+            transition={{ duration: 0.6 }}
+            className="relative space-y-6"
+          >
+            <SectionHeader
+              eyebrow="Suasana belajar harian"
+              eyebrowVariant="surface"
+              title="Jadwal penuh aktivitas yang menstimulasi seluruh aspek perkembangan anak"
+              description="Guru kami menyiapkan transisi yang mulus dari aktivitas indoor ke outdoor sehingga anak tetap bersemangat hingga waktu pulang."
+            />
+            <div className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-soft">
+              <p className="text-base font-semibold text-secondary">Kolaborasi dengan orang tua</p>
+              <p className="mt-3 text-base leading-relaxed text-text-muted">
+                Orang tua mendapatkan ringkasan kegiatan dan foto terbaik anak setiap hari melalui kanal komunikasi khusus.
+              </p>
+            </div>
+          </m.div>
+          <div className="relative space-y-4">
+            {journey.map((item, index) => (
+              <m.div
+                key={item.title}
+                initial={{ opacity: 0, y: 40 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, amount: 0.3 }}
+                transition={{ duration: 0.5, delay: index * 0.05 }}
+                className="grid gap-4 rounded-3xl border border-white/60 bg-white/85 p-6 shadow-soft sm:grid-cols-[auto,1fr] sm:items-center"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-secondary/10 text-2xl">
                     {item.icon}
                   </span>
-                  <h3 className="mt-6 text-xl font-semibold text-text">{item.title}</h3>
-                  <p className="mt-3 text-sm leading-relaxed text-text-muted">{item.description}</p>
-                </m.div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section id="program" className="relative py-12 md:py-20">
-          <div className="container grid gap-12 lg:grid-cols-[1fr,1fr] lg:items-start">
-            <m.div
-              initial={{ opacity: 0, y: 40 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, amount: 0.4 }}
-              transition={{ duration: 0.6 }}
-              className="space-y-6"
-            >
-              <span className="inline-flex items-center gap-2 rounded-full bg-secondary/10 px-4 py-2 text-sm font-semibold text-secondary">
-                Program unggulan
-              </span>
-              <h2 className="text-3xl font-bold leading-tight text-text sm:text-4xl">
-                Tiga jalur belajar yang disesuaikan dengan tahap tumbuh kembang anak
-              </h2>
-              <p className="text-lg leading-relaxed text-text-muted">
-                Setiap kelas dipandu guru inti dan guru pendamping dengan rasio kecil. Kami menyeimbangkan stimulasi akademik, karakter, dan kegiatan bermain bebas.
-              </p>
-              <ul className="space-y-3 text-sm text-text-muted">
-                <li className="flex items-start gap-3">
-                  <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">
-                    1
-                  </span>
-                  Observasi minat dan kebutuhan anak sebelum penempatan kelas.
-                </li>
-                <li className="flex items-start gap-3">
-                  <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">
-                    2
-                  </span>
-                  Rencana belajar individual yang dikirim ke orang tua di awal tema.
-                </li>
-                <li className="flex items-start gap-3">
-                  <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">
-                    3
-                  </span>
-                  Evaluasi menyenangkan melalui pameran karya dan pertunjukan kecil.
-                </li>
-              </ul>
-            </m.div>
-            <div className="grid gap-6">
-              {programs.map((program, index) => (
-                <m.div
-                  key={program.name}
-                  initial={{ opacity: 0, y: 40 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true, amount: 0.3 }}
-                  transition={{ duration: 0.55, delay: index * 0.08 }}
-                  className="card h-full border-white/70 bg-white/90 p-7 shadow-soft"
-                >
-                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                    <div>
-                      <p className="text-sm font-semibold uppercase tracking-wide text-secondary">
-                        {program.age}
-                      </p>
-                      <h3 className="mt-1 text-2xl font-semibold text-text">{program.name}</h3>
-                      <p className="mt-3 text-sm leading-relaxed text-text-muted">
-                        {program.description}
-                      </p>
-                    </div>
-                    <span className="inline-flex h-12 min-w-[3rem] items-center justify-center rounded-2xl bg-primary/15 text-2xl">
-                      ✨
-                    </span>
+                  <div>
+                    <p className="text-sm font-semibold text-secondary">{item.time} WIB</p>
+                    <p className="text-lg font-semibold text-text">{item.title}</p>
                   </div>
-                  <ul className="mt-6 space-y-2 text-sm text-text-muted">
-                    {program.points.map((point) => (
-                      <li key={point} className="flex items-start gap-3">
-                        <span className="mt-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-secondary/10 text-xs font-semibold text-secondary">
-                          ✓
-                        </span>
-                        {point}
-                      </li>
-                    ))}
-                  </ul>
-                </m.div>
-              ))}
-            </div>
+                </div>
+                <p className="text-base leading-relaxed text-text-muted sm:pl-4">{item.description}</p>
+              </m.div>
+            ))}
           </div>
-        </section>
-
-        <section id="pengalaman" className="relative overflow-hidden py-12 md:py-20">
-          <div className="absolute inset-0 bg-grid-dots [background-size:24px_24px] opacity-40" />
-          <div className="container relative grid gap-12 lg:grid-cols-[0.9fr,1.1fr] lg:items-center">
-            <m.div
-              initial={{ opacity: 0, y: 40 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, amount: 0.4 }}
-              transition={{ duration: 0.6 }}
-              className="space-y-6"
-            >
-              <span className="inline-flex items-center gap-2 rounded-full bg-white/80 px-4 py-2 text-sm font-semibold text-primary">
-                Suasana belajar harian
-              </span>
-              <h2 className="text-3xl font-bold leading-tight text-text sm:text-4xl">
-                Jadwal penuh aktivitas yang menstimulasi seluruh aspek perkembangan anak
-              </h2>
-              <p className="text-lg leading-relaxed text-text-muted">
-                Guru kami menyiapkan transisi yang mulus dari aktivitas indoor ke outdoor sehingga anak tetap bersemangat hingga waktu pulang.
-              </p>
-              <div className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-soft">
-                <p className="text-sm font-semibold text-secondary">Kolaborasi dengan orang tua</p>
-                <p className="mt-3 text-sm leading-relaxed text-text-muted">
-                  Orang tua mendapatkan ringkasan kegiatan dan foto terbaik anak setiap hari melalui kanal komunikasi khusus.
-                </p>
-              </div>
-            </m.div>
-            <div className="space-y-4">
-              {journey.map((item, index) => (
-                <m.div
-                  key={item.title}
-                  initial={{ opacity: 0, y: 40 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true, amount: 0.3 }}
-                  transition={{ duration: 0.5, delay: index * 0.05 }}
-                  className="grid gap-4 rounded-3xl border border-white/60 bg-white/85 p-6 shadow-soft sm:grid-cols-[auto,1fr] sm:items-center"
-                >
-                  <div className="flex items-center gap-3">
-                    <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-secondary/10 text-2xl">
-                      {item.icon}
-                    </span>
-                    <div>
-                      <p className="text-sm font-semibold text-secondary">{item.time} WIB</p>
-                      <p className="text-lg font-semibold text-text">{item.title}</p>
-                    </div>
-                  </div>
-                  <p className="text-sm leading-relaxed text-text-muted sm:pl-4">{item.description}</p>
-                </m.div>
-              ))}
-            </div>
-          </div>
-        </section>
+        </PageSection>
 
         <TestimonialList />
 
-        <section id="faq" className="relative py-12 md:py-20">
-          <div className="container grid gap-12 lg:grid-cols-[0.9fr,1fr] lg:items-start">
-            <m.div
-              initial={{ opacity: 0, y: 40 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, amount: 0.4 }}
-              transition={{ duration: 0.6 }}
-              className="space-y-6"
-            >
-              <span className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 text-sm font-semibold text-primary">
-                Pertanyaan populer
-              </span>
-              <h2 className="text-3xl font-bold leading-tight text-text sm:text-4xl">
-                Informasi penting seputar pendaftaran dan kegiatan sekolah
-              </h2>
-              <p className="text-lg leading-relaxed text-text-muted">
-                Jika ada pertanyaan lain, kami dengan senang hati menjawab melalui WhatsApp ataupun ketika Anda berkunjung langsung.
-              </p>
-              <CTAButton config={faqCta} className="w-full sm:w-auto" />
-            </m.div>
-            <div className="space-y-4">
-              {faqs.map((faq, index) => (
-                <m.div
-                  key={faq.question}
-                  initial={{ opacity: 0, y: 40 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true, amount: 0.3 }}
-                  transition={{ duration: 0.55, delay: index * 0.08 }}
-                  className="card border-white/70 bg-white/90 p-6 text-left shadow-soft"
-                >
-                  <p className="text-base font-semibold text-text">{faq.question}</p>
-                  <p className="mt-3 text-sm leading-relaxed text-text-muted">{faq.answer}</p>
-                </m.div>
-              ))}
-            </div>
+        <PageSection
+          id="faq"
+          padding="tight"
+          containerClassName="grid gap-12 lg:grid-cols-[0.9fr,1fr] lg:items-start"
+        >
+          <m.div
+            initial={{ opacity: 0, y: 40 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.4 }}
+            transition={{ duration: 0.6 }}
+            className="space-y-6"
+          >
+            <SectionHeader
+              eyebrow="Pertanyaan populer"
+              title="Informasi penting seputar pendaftaran dan kegiatan sekolah"
+              description="Jika ada pertanyaan lain, kami dengan senang hati menjawab melalui WhatsApp ataupun ketika Anda berkunjung langsung."
+            />
+            <CTAButton config={faqCta} className="w-full sm:w-auto" />
+          </m.div>
+          <div className="space-y-4">
+            {faqs.map((faq, index) => (
+              <m.div
+                key={faq.question}
+                initial={{ opacity: 0, y: 40 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, amount: 0.3 }}
+                transition={{ duration: 0.55, delay: index * 0.08 }}
+                className="card border-white/70 bg-white/90 p-6 text-left shadow-soft"
+              >
+                <p className="text-lg font-semibold text-text">{faq.question}</p>
+                <p className="mt-3 text-base leading-relaxed text-text-muted">{faq.answer}</p>
+              </m.div>
+            ))}
           </div>
-        </section>
+        </PageSection>
 
-        <section className="relative pb-36 pt-6">
-          <div className="container">
-            <m.div
-              initial={{ opacity: 0, y: 40 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, amount: 0.4 }}
-              transition={{ duration: 0.6 }}
-              className="card flex flex-col gap-6 overflow-hidden border-white/70 bg-gradient-to-br from-secondary/10 via-white to-primary/10 p-10 text-center md:flex-row md:items-center md:justify-between md:text-left"
-            >
-              <div className="max-w-xl space-y-3">
-                <span className="inline-flex items-center gap-2 rounded-full bg-white/70 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-secondary">
-                  Siap bergabung
-                </span>
-                <h2 className="text-3xl font-semibold text-text sm:text-4xl">
-                  Jadwalkan tur sekolah dan rasakan langsung keceriaan anak-anak TK Kartikasari
-                </h2>
-                <p className="text-sm leading-relaxed text-text-muted">
-                  Kami membuka sesi kunjungan setiap Senin dan Kamis. Tim kami akan menemani Anda berkeliling kelas, taman bermain, hingga ruang kegiatan khusus.
-                </p>
-              </div>
-              <div className="flex flex-col gap-3 md:flex-row md:items-center">
-                <CTAButton config={visitCta} className="w-full md:w-auto" />
-                <a href="#program" className="btn-outline w-full md:w-auto">
-                  Lihat program kembali
-                </a>
-              </div>
-            </m.div>
-          </div>
-        </section>
+        <PageSection className="relative pb-36" padding="tight">
+          <m.div
+            initial={{ opacity: 0, y: 40 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.4 }}
+            transition={{ duration: 0.6 }}
+            className="card flex flex-col gap-6 overflow-hidden border-white/70 bg-gradient-to-br from-secondary/10 via-white to-primary/10 p-10 text-center md:flex-row md:items-center md:justify-between md:text-left"
+          >
+            <div className="max-w-xl space-y-4">
+              <span className="inline-flex items-center gap-2 rounded-full bg-white/70 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-secondary">
+                Siap bergabung
+              </span>
+              <h2 className="text-balance text-3xl font-semibold text-text sm:text-4xl">
+                Jadwalkan tur sekolah dan rasakan langsung keceriaan anak-anak TK Kartikasari
+              </h2>
+              <p className="text-base leading-relaxed text-text-muted">
+                Kami membuka sesi kunjungan setiap Senin dan Kamis. Tim kami akan menemani Anda berkeliling kelas, taman bermain, hingga ruang kegiatan khusus.
+              </p>
+            </div>
+            <div className="flex flex-col gap-3 md:flex-row md:items-center">
+              <CTAButton config={visitCta} className="w-full md:w-auto" />
+              <a href="#program" className="btn-outline w-full md:w-auto">
+                Lihat program kembali
+              </a>
+            </div>
+          </m.div>
+        </PageSection>
 
         <StickyActions />
       </>

--- a/tk-kartikasari/components/layout/PageHeader.tsx
+++ b/tk-kartikasari/components/layout/PageHeader.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+import PageSection from "./PageSection";
+
+type PageHeaderProps = {
+  eyebrow?: string;
+  title: string;
+  description?: ReactNode;
+  align?: "left" | "center";
+  eyebrowClassName?: string;
+  className?: string;
+  children?: ReactNode;
+};
+
+export default function PageHeader({
+  eyebrow,
+  title,
+  description,
+  align = "left",
+  eyebrowClassName,
+  className,
+  children,
+}: PageHeaderProps) {
+  return (
+    <PageSection padding="tight">
+      <header
+        className={cn(
+          "space-y-5",
+          align === "center" ? "mx-auto max-w-3xl text-center" : "max-w-3xl",
+          className,
+        )}
+      >
+        {eyebrow ? (
+          <p
+            className={cn(
+              "text-xs font-semibold uppercase tracking-[0.28em] text-secondary",
+              eyebrowClassName,
+            )}
+          >
+            {eyebrow}
+          </p>
+        ) : null}
+        <h1 className="text-balance text-4xl font-semibold text-text sm:text-5xl">
+          {title}
+        </h1>
+        {description ? (
+          <p className="text-pretty text-base leading-relaxed text-text-muted sm:text-lg">
+            {description}
+          </p>
+        ) : null}
+        {children}
+      </header>
+    </PageSection>
+  );
+}

--- a/tk-kartikasari/components/layout/PageSection.tsx
+++ b/tk-kartikasari/components/layout/PageSection.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type PageSectionProps = {
+  id?: string;
+  as?: keyof JSX.IntrinsicElements;
+  padding?: "default" | "tight" | "relaxed" | "none";
+  container?: boolean;
+  className?: string;
+  containerClassName?: string;
+  children: ReactNode;
+};
+
+const paddingMap: Record<NonNullable<PageSectionProps["padding"]>, string> = {
+  default: "py-16 sm:py-20",
+  tight: "py-12 sm:py-16",
+  relaxed: "py-20 sm:py-24",
+  none: "",
+};
+
+export default function PageSection({
+  id,
+  as: Component = "section",
+  padding = "default",
+  container = true,
+  className,
+  containerClassName,
+  children,
+}: PageSectionProps) {
+  const paddingClasses = paddingMap[padding];
+
+  const content = container ? (
+    <div className={cn("container", containerClassName)}>{children}</div>
+  ) : (
+    children
+  );
+
+  return (
+    <Component id={id} className={cn(paddingClasses, className)}>
+      {content}
+    </Component>
+  );
+}

--- a/tk-kartikasari/components/layout/SectionHeader.tsx
+++ b/tk-kartikasari/components/layout/SectionHeader.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type SectionHeaderProps = {
+  eyebrow?: ReactNode;
+  eyebrowVariant?: "primary" | "secondary" | "surface" | "muted";
+  title: string;
+  description?: ReactNode;
+  align?: "left" | "center";
+  className?: string;
+  titleClassName?: string;
+  descriptionClassName?: string;
+};
+
+const eyebrowStyles: Record<NonNullable<SectionHeaderProps["eyebrowVariant"]>, string> = {
+  primary: "bg-primary/15 text-primary",
+  secondary: "bg-secondary/15 text-secondary",
+  surface: "bg-white/80 text-secondary",
+  muted: "bg-border/40 text-text",
+};
+
+export default function SectionHeader({
+  eyebrow,
+  eyebrowVariant = "primary",
+  title,
+  description,
+  align = "left",
+  className,
+  titleClassName,
+  descriptionClassName,
+}: SectionHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "space-y-4",
+        align === "center" ? "mx-auto max-w-3xl text-center" : "max-w-2xl",
+        className,
+      )}
+    >
+      {eyebrow ? (
+        <span
+          className={cn(
+            "inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-xs font-semibold uppercase tracking-wide",
+            eyebrowStyles[eyebrowVariant],
+          )}
+        >
+          {eyebrow}
+        </span>
+      ) : null}
+      <h2
+        className={cn(
+          "text-balance text-3xl font-semibold text-text sm:text-4xl",
+          titleClassName,
+        )}
+      >
+        {title}
+      </h2>
+      {description ? (
+        <p
+          className={cn(
+            "text-pretty text-base text-text-muted sm:text-lg",
+            descriptionClassName,
+          )}
+        >
+          {description}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/tk-kartikasari/lib/utils.ts
+++ b/tk-kartikasari/lib/utils.ts
@@ -1,3 +1,9 @@
+type ClassValue = string | number | false | null | undefined
+
+export function cn(...inputs: ClassValue[]) {
+  return inputs.filter(Boolean).join(' ')
+}
+
 export function waLink(message: string) {
   const phone = '6285227227826'
   const text = encodeURIComponent(message)


### PR DESCRIPTION
## Summary
- enlarge the global typography scale for mobile and add layout helpers to provide consistent spacing
- refactor the homepage and shared navigation/components to adopt the new typographic rhythm
- update interior pages to use reusable page sections and headers so copy is easier to read on small screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2681efa74832f8952e358498b7bde