### PR TITLE
Align mobile menu to right and widen dropdown

### DIFF
--- a/tk-kartikasari/.gitignore
+++ b/tk-kartikasari/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/tk-kartikasari/app/layout.tsx
+++ b/tk-kartikasari/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <div className="relative min-h-screen">
           <header className="sticky top-0 z-50 border-b border-white/60 bg-white/90 shadow-sm backdrop-blur">
             <div className="container">
-              <div className="flex w-full items-center gap-3 py-3 md:gap-5 md:py-4">
+              <div className="relative flex w-full items-center gap-3 py-3 md:gap-5 md:py-4">
                 <Link
                   href="/"
                   className="flex shrink-0 items-center gap-3 text-text transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
@@ -33,7 +33,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   </span>
                 </Link>
                 <DesktopNav />
-                <div className="flex shrink-0 items-center gap-2 sm:gap-3">
+                <div className="ml-auto flex flex-1 items-center justify-end gap-2 sm:gap-3 lg:ml-0 lg:flex-none">
                   <Link
                     href="/ppdb"
                     className="hidden rounded-full border border-border/70 px-4 py-2 text-sm font-semibold text-text transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 md:inline-flex"

--- a/tk-kartikasari/components/MobileNav.tsx
+++ b/tk-kartikasari/components/MobileNav.tsx
@@ -14,7 +14,7 @@ export default function MobileNav() {
   const closeMenu = () => setOpen(false);
 
   return (
-    <div className="relative lg:hidden">
+    <div className="lg:hidden">
       <motion.button
         type="button"
         onClick={() => setOpen((prev) => !prev)}
@@ -46,7 +46,7 @@ export default function MobileNav() {
         {open ? (
           <motion.div
             id="mobile-nav"
-            className="absolute right-0 top-14 z-50 w-64 rounded-3xl border border-border/70 bg-white/95 p-4 shadow-xl backdrop-blur"
+            className="absolute left-0 right-0 top-[calc(100%+0.75rem)] z-50 rounded-3xl border border-border/70 bg-white/95 p-4 shadow-xl backdrop-blur"
             initial={{ opacity: 0, y: -8 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -8 }}
@@ -64,7 +64,7 @@ export default function MobileNav() {
                     href={item.href}
                     onClick={closeMenu}
                     aria-current={isActive ? "page" : undefined}
-                    className={`rounded-full px-4 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
+                    className={`block rounded-full px-4 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
                       isActive
                         ? "bg-primary/10 text-primary"
                         : "text-text-muted hover:bg-surfaceAlt hover:text-text"


### PR DESCRIPTION
## Summary
- align the header action group so the mobile hamburger button sits on the right edge while keeping desktop layout intact
- expand the mobile navigation dropdown to span the header width and make each link take full row width
- add a .gitignore entry for node_modules to avoid tracking installed dependencies

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2a5c45520832fbbe7bcda1781898a