### PR TITLE
feat: implement multi-page migration and seo metadata

### DIFF
--- a/tk-kartikasari/app/agenda/page.tsx
+++ b/tk-kartikasari/app/agenda/page.tsx
@@ -1,6 +1,7 @@
 import PageHeader from "@/components/layout/PageHeader";
 import PageSection from "@/components/layout/PageSection";
 import agenda from "@/data/agenda.json";
+import { createPageMetadata } from "@/lib/metadata";
 
 type AgendaItem = (typeof agenda)[number];
 
@@ -13,6 +14,15 @@ function formatDate(value: string) {
   });
 }
 
+const agendaDescription =
+  "Agenda disusun untuk melibatkan anak dan orang tua dalam pengalaman belajar yang menyenangkan serta penuh kolaborasi. Simpan tanggal penting berikut di kalender keluarga Anda.";
+
+export const metadata = createPageMetadata({
+  title: "Agenda",
+  description: agendaDescription,
+  path: "/agenda",
+});
+
 export default function Page() {
   const items = [...agenda].sort(
     (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
@@ -24,7 +34,7 @@ export default function Page() {
       <PageHeader
         eyebrow="Agenda"
         title="Agenda Kegiatan TK Kartikasari"
-        description="Agenda disusun untuk melibatkan anak dan orang tua dalam pengalaman belajar yang menyenangkan serta penuh kolaborasi. Simpan tanggal penting berikut di kalender keluarga Anda."
+        description={agendaDescription}
       />
 
       <PageSection padding="tight">

--- a/tk-kartikasari/app/galeri/page.tsx
+++ b/tk-kartikasari/app/galeri/page.tsx
@@ -3,8 +3,18 @@ import Link from "next/link";
 import PageHeader from "@/components/layout/PageHeader";
 import PageSection from "@/components/layout/PageSection";
 import data from "@/data/galeri.json";
+import { createPageMetadata } from "@/lib/metadata";
 
 type GaleriItem = (typeof data)[number];
+
+const galeriDescription =
+  "Potret kegiatan anak TK Kartikasari dalam suasana belajar yang hangat, aktif, dan menyenangkan. Semua foto dimuat dengan teknik lazy-load agar halaman tetap ringan.";
+
+export const metadata = createPageMetadata({
+  title: "Galeri",
+  description: galeriDescription,
+  path: "/galeri",
+});
 
 export default function Page() {
   const hasPhotos = data.length > 0;
@@ -14,7 +24,7 @@ export default function Page() {
       <PageHeader
         eyebrow="Galeri"
         title="Galeri Kegiatan Anak"
-        description="Potret kegiatan anak TK Kartikasari dalam suasana belajar yang hangat, aktif, dan menyenangkan. Semua foto dimuat dengan teknik lazy-load agar halaman tetap ringan."
+        description={galeriDescription}
       />
 
       <PageSection padding="tight">

--- a/tk-kartikasari/app/kontak/page.tsx
+++ b/tk-kartikasari/app/kontak/page.tsx
@@ -4,6 +4,16 @@ import PageSection from "@/components/layout/PageSection";
 import MapEmbed from "@/components/MapEmbed";
 import { contactConsultationCTA } from "@/content/cta";
 import site from "@/data/site.json";
+import { createPageMetadata } from "@/lib/metadata";
+
+const contactDescription =
+  "Kami siap membantu informasi seputar PPDB, jadwal kunjungan sekolah, maupun kebutuhan administrasi lainnya. Gunakan detail di bawah ini atau langsung hubungi kami melalui WhatsApp.";
+
+export const metadata = createPageMetadata({
+  title: "Kontak",
+  description: contactDescription,
+  path: "/kontak",
+});
 
 const info = [
   { label: "Alamat", value: site.address },
@@ -18,7 +28,7 @@ export default function Page() {
       <PageHeader
         eyebrow="Kontak"
         title="Hubungi TK Kartikasari"
-        description="Kami siap membantu informasi seputar PPDB, jadwal kunjungan sekolah, maupun kebutuhan administrasi lainnya. Gunakan detail di bawah ini atau langsung hubungi kami melalui WhatsApp."
+        description={contactDescription}
       />
 
       <PageSection padding="tight" containerClassName="grid gap-6 md:grid-cols-[1.1fr,0.9fr] md:items-start">

--- a/tk-kartikasari/app/layout.tsx
+++ b/tk-kartikasari/app/layout.tsx
@@ -5,11 +5,34 @@ import Link from "next/link";
 import { waLink } from "@/lib/utils";
 import MobileNav from "@/components/MobileNav";
 import DesktopNav from "@/components/DesktopNav";
+import StickyActions from "@/components/StickyActions";
 
 export const metadata: Metadata = {
-  title: "TK Kartikasari Bulaksari Bantarsari Cilacap — Taman Kanak-kanak",
+  metadataBase: new URL(site.siteUrl),
+  title: {
+    default: `${site.schoolName} Bulaksari Bantarsari Cilacap — Taman Kanak-kanak`,
+    template: `%s | ${site.schoolName}`,
+  },
   description:
     "Lingkungan aman, hangat, dan menstimulasi untuk anak usia dini di Bulaksari, Bantarsari, Cilacap. Info PPDB via WhatsApp.",
+  openGraph: {
+    title: `${site.schoolName} Bulaksari Bantarsari Cilacap — Taman Kanak-kanak`,
+    description:
+      "Lingkungan aman, hangat, dan menstimulasi untuk anak usia dini di Bulaksari, Bantarsari, Cilacap. Info PPDB via WhatsApp.",
+    url: site.siteUrl,
+    siteName: site.schoolName,
+    locale: "id_ID",
+    type: "website",
+  },
+  alternates: {
+    canonical: site.siteUrl,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${site.schoolName} Bulaksari Bantarsari Cilacap — Taman Kanak-kanak`,
+    description:
+      "Lingkungan aman, hangat, dan menstimulasi untuk anak usia dini di Bulaksari, Bantarsari, Cilacap. Info PPDB via WhatsApp.",
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -112,6 +135,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               © {new Date().getFullYear()} {site.schoolName}. Semua hak cipta dilindungi.
             </div>
           </footer>
+          <StickyActions />
         </div>
       </body>
     </html>

--- a/tk-kartikasari/app/page.tsx
+++ b/tk-kartikasari/app/page.tsx
@@ -1,139 +1,41 @@
 import HomePageContent from "@/components/home/HomePageContent";
+import JsonLd from "@/components/JsonLd";
 import { faqInquiryCTA, heroVisitCTA, visitScheduleCTA } from "@/content/cta";
+import {
+  homeFaqs,
+  homeHeroDescription,
+  homeHighlights,
+  homeJourney,
+  homePrograms,
+  homeStats,
+} from "@/content/home";
 import site from "@/data/site.json";
+import { createPageMetadata } from "@/lib/metadata";
+import { preschoolSchema } from "@/lib/schema";
 
-const stats = [
-  { value: "15+", label: "Tahun mendampingi anak Bulaksari" },
-  { value: "8", label: "Kegiatan tematik kreatif setiap minggu" },
-  { value: "100%", label: "Pendampingan perkembangan harian" },
-];
-
-const highlights = [
-  {
-    icon: "🎨",
-    title: "Belajar sambil berkarya",
-    description:
-      "Proyek seni, eksperimen sains sederhana, hingga dapur mini membuat anak senang bereksplorasi.",
-  },
-  {
-    icon: "🤝",
-    title: "Kolaborasi guru & orang tua",
-    description:
-      "Laporan perkembangan dikirim rutin dan kelas parenting singkat hadirkan tips mendampingi anak di rumah.",
-  },
-  {
-    icon: "🌱",
-    title: "Fokus karakter & kemandirian",
-    description:
-      "Rutinitas sederhana menumbuhkan rasa tanggung jawab, sopan santun, dan kepercayaan diri.",
-  },
-];
-
-const programs = [
-  {
-    name: "Kelas Bintang",
-    age: "Usia 4-5 tahun",
-    description:
-      "Kurikulum bermain terpadu untuk mengenal huruf, angka, dan kemampuan sosial dasar.",
-    points: [
-      "Senam pagi dan circle time menyenangkan",
-      "Eksplorasi sensorik dan role play",
-      "Pengenalan literasi melalui cerita dan lagu",
-    ],
-  },
-  {
-    name: "Kelas Pelangi",
-    age: "Usia 5-6 tahun",
-    description:
-      "Persiapan menuju SD dengan proyek tematik dan kegiatan memecahkan masalah sederhana.",
-    points: [
-      "Proyek STEAM mingguan",
-      "Pembiasaan menulis dan berhitung ringan",
-      "Field trip edukatif ke lingkungan sekitar",
-    ],
-  },
-  {
-    name: "Ekstrakurikuler Ceria",
-    age: "Setiap Jumat",
-    description:
-      "Pilihan kelas tambahan seperti tari, tahfidz, dan kreativitas memasak untuk menyalurkan minat anak.",
-    points: [
-      "Dipandu instruktur ramah dan tersertifikasi",
-      "Pertunjukan kecil tiap akhir tema",
-      "Terbuka untuk kolaborasi dengan komunitas",
-    ],
-  },
-];
-
-const journey = [
-  {
-    time: "07.00",
-    title: "Penyambutan ceria",
-    description: "Guru menyapa anak satu per satu, memeriksa kesiapan, dan mengajak permainan ringan.",
-    icon: "🌞",
-  },
-  {
-    time: "08.00",
-    title: "Lingkar pagi",
-    description:
-      "Anak berbagi cerita, bernyanyi, dan belajar nilai moral sederhana bersama teman-teman.",
-    icon: "🗣️",
-  },
-  {
-    time: "09.00",
-    title: "Eksplorasi proyek",
-    description: "Setiap hari ada pusat kegiatan berbeda: seni, sains, balok, hingga dapur mini.",
-    icon: "🔍",
-  },
-  {
-    time: "10.30",
-    title: "Waktu luar ruang",
-    description: "Bermain di taman mini, berkebun, dan aktivitas motorik kasar secara aman dan terarah.",
-    icon: "🏃",
-  },
-  {
-    time: "11.30",
-    title: "Refleksi & doa",
-    description: "Anak merangkum pengalaman hari itu, membaca doa, lalu pulang dengan perasaan bahagia.",
-    icon: "🙏",
-  },
-];
-
-const faqs = [
-  {
-    question: "Apa keunggulan utama TK Kartikasari?",
-    answer:
-      "Kami menghadirkan lingkungan belajar yang hangat, aman, dan kaya stimulasi. Guru-guru berpengalaman mendampingi anak dengan pendekatan personal agar setiap potensi tumbuh maksimal.",
-  },
-  {
-    question: "Bagaimana proses penerimaan peserta didik baru?",
-    answer:
-      "Cukup hubungi Bu Mintarsih melalui WhatsApp untuk jadwal observasi. Orang tua dapat mengisi formulir, konsultasi kebutuhan anak, lalu mengikuti sesi pengenalan kelas.",
-  },
-  {
-    question: "Apakah sekolah menyediakan laporan perkembangan?",
-    answer:
-      "Ya. Laporan harian singkat dibagikan lewat grup komunikasi, sedangkan laporan perkembangan lengkap diberikan setiap akhir tema dan semester.",
-  },
-  {
-    question: "Bagaimana keterlibatan orang tua di sekolah?",
-    answer:
-      "Kami rutin mengadakan kelas parenting singkat, hari kunjungan orang tua, dan kolaborasi proyek sehingga keluarga terlibat aktif dalam proses belajar anak.",
-  },
-];
+export const metadata = createPageMetadata({
+  title: "Beranda",
+  description: homeHeroDescription,
+  path: "/",
+});
 
 export default function Page() {
+  const schema = preschoolSchema();
+
   return (
-    <HomePageContent
-      schoolName={site.schoolName}
-      stats={stats}
-      highlights={highlights}
-      programs={programs}
-      journey={journey}
-      faqs={faqs}
-      heroCta={heroVisitCTA}
-      faqCta={faqInquiryCTA}
-      visitCta={visitScheduleCTA}
-    />
+    <>
+      <HomePageContent
+        schoolName={site.schoolName}
+        stats={homeStats}
+        highlights={homeHighlights}
+        programs={homePrograms}
+        journey={homeJourney}
+        faqs={homeFaqs}
+        heroCta={heroVisitCTA}
+        faqCta={faqInquiryCTA}
+        visitCta={visitScheduleCTA}
+      />
+      <JsonLd data={schema} />
+    </>
   );
 }

--- a/tk-kartikasari/app/pengumuman/page.tsx
+++ b/tk-kartikasari/app/pengumuman/page.tsx
@@ -1,6 +1,7 @@
 import PageHeader from "@/components/layout/PageHeader";
 import PageSection from "@/components/layout/PageSection";
 import data from "@/data/pengumuman.json";
+import { createPageMetadata } from "@/lib/metadata";
 
 type Pengumuman = (typeof data)[number];
 
@@ -16,6 +17,15 @@ function isExternal(url: string) {
   return url.startsWith("http");
 }
 
+const pengumumanDescription =
+  "Pantau kabar terbaru terkait PPDB, agenda orang tua, hingga informasi akademik dan libur sekolah. Daftar berikut akan diperbarui secara berkala.";
+
+export const metadata = createPageMetadata({
+  title: "Pengumuman",
+  description: pengumumanDescription,
+  path: "/pengumuman",
+});
+
 export default function Page() {
   const items = [...data].sort(
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
@@ -26,7 +36,7 @@ export default function Page() {
       <PageHeader
         eyebrow="Pengumuman"
         title="Info Resmi TK Kartikasari"
-        description="Pantau kabar terbaru terkait PPDB, agenda orang tua, hingga informasi akademik dan libur sekolah. Daftar berikut akan diperbarui secara berkala."
+        description={pengumumanDescription}
       />
 
       <PageSection padding="tight">

--- a/tk-kartikasari/app/ppdb/page.tsx
+++ b/tk-kartikasari/app/ppdb/page.tsx
@@ -3,37 +3,15 @@ import PageHeader from "@/components/layout/PageHeader";
 import PageSection from "@/components/layout/PageSection";
 import PpdbForm from "@/components/PpdbForm";
 import { ppdbHeadmasterCTA } from "@/content/cta";
+import { ppdbFaqs, ppdbMetaDescription, ppdbSteps } from "@/content/ppdb";
 import site from "@/data/site.json";
+import { createPageMetadata } from "@/lib/metadata";
 
-const steps = [
-  "Hubungi Ibu Mintarsih melalui WhatsApp untuk mengatur jadwal kunjungan sekolah.",
-  "Datang ke TK Kartikasari sesuai jadwal yang disepakati untuk observasi singkat.",
-  "Lengkapi formulir data anak dan diskusi kebutuhan khusus bersama guru.",
-  "Lakukan pembayaran administrasi awal sesuai informasi dari sekolah.",
-];
-
-const faqs = [
-  {
-    question: "Kapan pendaftaran dibuka?",
-    answer:
-      "Pendaftaran dibuka sepanjang tahun ajaran berjalan. Kuota terbatas sehingga kami sarankan menghubungi sekolah lebih awal.",
-  },
-  {
-    question: "Dokumen apa saja yang perlu dibawa?",
-    answer:
-      "Fotokopi akta kelahiran anak, kartu keluarga, kartu identitas orang tua, dan buku imunisasi (jika ada).",
-  },
-  {
-    question: "Apakah ada biaya formulir?",
-    answer:
-      "Tidak ada biaya formulir. Pembayaran dilakukan setelah anak dinyatakan diterima dan menyepakati jadwal masuk.",
-  },
-  {
-    question: "Apakah ada program trial class?",
-    answer:
-      "Ada. Orang tua dapat meminta jadwal percobaan satu hari untuk memastikan anak nyaman sebelum resmi bergabung.",
-  },
-];
+export const metadata = createPageMetadata({
+  title: "PPDB",
+  description: ppdbMetaDescription,
+  path: "/ppdb",
+});
 
 export default function Page() {
   return (
@@ -51,7 +29,7 @@ export default function Page() {
             <p className="text-base text-text-muted">Panduan singkat agar proses pendaftaran berjalan lancar.</p>
           </div>
           <ol className="list-decimal space-y-3 pl-5 text-base text-text">
-            {steps.map((step) => (
+            {ppdbSteps.map((step) => (
               <li key={step}>{step}</li>
             ))}
           </ol>
@@ -66,8 +44,7 @@ export default function Page() {
           <div className="space-y-2">
             <h2 className="text-3xl font-semibold">Formulir Online</h2>
             <p className="text-base text-text-muted">
-              Isi data singkat berikut untuk mempercepat proses pendaftaran. Setelah dikirim, WhatsApp akan terbuka otomatis dan
-              tim kami akan menindaklanjuti.
+              Isi data singkat berikut untuk mempercepat proses pendaftaran. Setelah dikirim, WhatsApp akan terbuka otomatis dan tim kami akan menindaklanjuti.
             </p>
           </div>
           <PpdbForm />
@@ -81,7 +58,7 @@ export default function Page() {
         <div className="card space-y-5 p-7">
           <h2 className="text-3xl font-semibold">FAQ Pendaftaran</h2>
           <div className="space-y-3">
-            {faqs.map((item) => (
+            {ppdbFaqs.map((item) => (
               <details key={item.question} className="group rounded-2xl border border-border/70 bg-white p-5">
                 <summary className="cursor-pointer text-lg font-semibold text-text">
                   {item.question}

--- a/tk-kartikasari/app/program/page.tsx
+++ b/tk-kartikasari/app/program/page.tsx
@@ -1,81 +1,18 @@
 import PageHeader from "@/components/layout/PageHeader";
 import PageSection from "@/components/layout/PageSection";
+import {
+  programClasses,
+  programLearningMethods,
+  programWeeklySchedule,
+  programsMetaDescription,
+} from "@/content/programs";
+import { createPageMetadata } from "@/lib/metadata";
 
-const classes = [
-  {
-    name: "Kelas A • Bintang Kecil",
-    age: "Usia 4–5 tahun",
-    description:
-      "Masa peralihan dari playgroup menuju TK yang fokus pada eksplorasi sensorik, bahasa awal, dan kemandirian sederhana.",
-    focus: [
-      "Pembiasaan rutinitas dan sopan santun sehari-hari",
-      "Koordinasi motorik halus melalui aktivitas seni dan konstruksi",
-      "Pengayaan kosa kata lewat cerita, lagu, dan permainan peran",
-    ],
-  },
-  {
-    name: "Kelas B • Pelangi Ceria",
-    age: "Usia 5–6 tahun",
-    description:
-      "Persiapan menuju sekolah dasar dengan penguatan literasi, numerasi, dan kemampuan sosial memimpin kelompok.",
-    focus: [
-      "Eksperimen STEAM sederhana dan proyek tematik mingguan",
-      "Pembiasaan menulis nama, membaca suku kata, dan berhitung konkret",
-      "Latihan presentasi mini untuk membangun rasa percaya diri",
-    ],
-  },
-];
-
-const learningMethods = [
-  {
-    title: "Sentra tematik",
-    description:
-      "Setiap hari anak bergiliran di sentra seni, balok, main peran, sains, dan persiapan agar pengalaman belajar kaya dan seimbang.",
-  },
-  {
-    title: "Pendampingan individual",
-    description:
-      "Guru melakukan observasi harian dan catatan perkembangan sehingga kebutuhan masing-masing anak dapat ditindaklanjuti.",
-  },
-  {
-    title: "Kolaborasi orang tua",
-    description:
-      "Laporan kegiatan dibagikan melalui WhatsApp dan sesi konsultasi bulanan untuk menyepakati strategi di rumah.",
-  },
-  {
-    title: "Belajar di luar ruang",
-    description:
-      "Kegiatan berkebun, senam irama, dan eksplorasi lingkungan sekitar menyeimbangkan stimulasi fisik dan sosial anak.",
-  },
-];
-
-const weeklySchedule = [
-  {
-    day: "Senin",
-    theme: "Pembukaan tema & circle time",
-    highlight: "Senam pagi, diskusi nilai moral, dan pengenalan kosa kata baru.",
-  },
-  {
-    day: "Selasa",
-    theme: "Eksperimen & sains sederhana",
-    highlight: "Percobaan warna, air, atau alam yang memantik rasa ingin tahu.",
-  },
-  {
-    day: "Rabu",
-    theme: "Karya kreatif",
-    highlight: "Melukis, kolase, hingga dapur mini untuk melatih motorik halus.",
-  },
-  {
-    day: "Kamis",
-    theme: "Berhitung dan literasi awal",
-    highlight: "Permainan angka, pengenalan huruf, dan membaca cerita interaktif.",
-  },
-  {
-    day: "Jumat",
-    theme: "Eksplorasi luar ruang & ekstrakurikuler",
-    highlight: "Berkebun, bermain peran, serta pilihan kelas tari, tahfidz, atau musik.",
-  },
-];
+export const metadata = createPageMetadata({
+  title: "Program",
+  description: programsMetaDescription,
+  path: "/program",
+});
 
 export default function Page() {
   return (
@@ -87,7 +24,7 @@ export default function Page() {
       />
 
       <PageSection padding="tight" containerClassName="grid gap-6 lg:grid-cols-2">
-        {classes.map((item) => (
+        {programClasses.map((item) => (
           <article key={item.name} className="card space-y-4 p-7">
             <div>
               <h2 className="text-3xl font-semibold">{item.name}</h2>
@@ -107,7 +44,7 @@ export default function Page() {
         <div className="card space-y-6 p-7">
           <h2 className="text-3xl font-semibold">Metode Belajar</h2>
           <div className="grid gap-4 md:grid-cols-2">
-            {learningMethods.map((method) => (
+            {programLearningMethods.map((method) => (
               <div key={method.title} className="rounded-2xl border border-border/60 bg-white p-6">
                 <h3 className="text-xl font-semibold text-secondary">{method.title}</h3>
                 <p className="mt-2 text-base text-text-muted">{method.description}</p>
@@ -126,7 +63,7 @@ export default function Page() {
             </p>
           </div>
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {weeklySchedule.map((item) => (
+            {programWeeklySchedule.map((item) => (
               <div key={item.day} className="rounded-2xl border border-border/60 bg-secondary/5 p-5">
                 <p className="text-xs font-semibold uppercase tracking-wide text-secondary">{item.day}</p>
                 <p className="mt-1 text-lg font-semibold text-text">{item.theme}</p>

--- a/tk-kartikasari/app/tentang/page.tsx
+++ b/tk-kartikasari/app/tentang/page.tsx
@@ -2,7 +2,16 @@ import Link from "next/link";
 
 import PageHeader from "@/components/layout/PageHeader";
 import PageSection from "@/components/layout/PageSection";
+import {
+  aboutDailyRhythm,
+  aboutExperiencePillars,
+  aboutHeaderHighlights,
+  aboutMetaDescription,
+  aboutMission,
+  aboutStrengths,
+} from "@/content/about";
 import site from "@/data/site.json";
+import { createPageMetadata } from "@/lib/metadata";
 
 const profileItems = [
   { label: "Nama Sekolah", value: site.schoolName },
@@ -12,73 +21,11 @@ const profileItems = [
   { label: "Jam Buka", value: site.openingHours },
 ];
 
-const headerHighlights = [
-  "Lingkungan aman & ramah anak",
-  "Guru komunikatif dengan orang tua",
-  "Belajar melalui bermain tematik",
-];
-
-const experiencePillars = [
-  {
-    title: "Hangat & Personal",
-    description:
-      "Guru menyapa anak satu per satu sambil mengenali kebiasaan, minat, dan kebutuhan unik mereka.",
-  },
-  {
-    title: "Aktivitas Bermakna",
-    description:
-      "Proyek tematik, bermain peran, dan eksplorasi alam menumbuhkan rasa percaya diri serta imajinasi.",
-  },
-  {
-    title: "Karakter Sehari-hari",
-    description:
-      "Nilai sopan santun, tanggung jawab, dan empati dipraktikkan melalui rutinitas sederhana yang menyenangkan.",
-  },
-];
-
-const dailyRhythm = [
-  {
-    title: "Sesi Pembuka yang Hangat",
-    description:
-      "Anak mengikuti doa, lagu, dan berbagi perasaan agar siap memulai hari dengan pikiran positif.",
-  },
-  {
-    title: "Eksplorasi Sentra & Outdoor",
-    description:
-      "Kegiatan berpindah antar sentra, eksperimen sains mini, dan bermain di luar menyalurkan energi anak.",
-  },
-  {
-    title: "Refleksi & Berbagi Cerita",
-    description:
-      "Anak diajak menceritakan penemuannya, merapikan alat, lalu menutup hari dengan lagu favorit bersama.",
-  },
-];
-
-const strengths = [
-  {
-    title: "Ruang Belajar Tematik",
-    description:
-      "Sentra literasi, sains mini, dan area seni memancing rasa ingin tahu sekaligus melatih motorik halus.",
-  },
-  {
-    title: "Rutinitas Penuh Makna",
-    description:
-      "Agenda harian menyeimbangkan kegiatan aktif dan tenang sehingga energi anak tetap stabil.",
-  },
-  {
-    title: "Kemitraan dengan Orang Tua",
-    description:
-      "Catatan perkembangan, foto kegiatan, dan temu wicara rutin menjaga keterlibatan keluarga.",
-  },
-];
-
-const mission = [
-  "Menumbuhkan rasa percaya diri, empati, dan kemandirian melalui kegiatan yang menyenangkan.",
-  "Menyediakan pengalaman tematik yang merangsang kreativitas, bahasa, dan numerasi awal.",
-  "Menguatkan kolaborasi guru dan orang tua melalui komunikasi harian yang bermakna.",
-  "Menghidupkan nilai moral, spiritual, dan cinta lingkungan dalam rutinitas anak.",
-  "Menciptakan lingkungan aman, bersih, dan inklusif yang menghargai keberagaman.",
-];
+export const metadata = createPageMetadata({
+  title: "Tentang",
+  description: aboutMetaDescription,
+  path: "/tentang",
+});
 
 export default function Page() {
   return (
@@ -95,7 +42,7 @@ export default function Page() {
         }
       >
         <div className="flex flex-wrap gap-3 pt-4">
-          {headerHighlights.map((item) => (
+          {aboutHeaderHighlights.map((item) => (
             <span
               key={item}
               className="inline-flex items-center gap-2 rounded-full border border-secondary/40 bg-white/80 px-4 py-2 text-sm font-medium text-secondary transition-all duration-300 hover:-translate-y-0.5 hover:border-secondary hover:bg-secondary/10"
@@ -131,7 +78,7 @@ export default function Page() {
               sederhana.
             </p>
             <ul className="grid gap-3 sm:grid-cols-3">
-              {experiencePillars.map((pillar) => (
+              {aboutExperiencePillars.map((pillar) => (
                 <li
                   key={pillar.title}
                   className="group relative overflow-hidden rounded-2xl border border-white/50 bg-white/80 p-4 transition-all duration-300 hover:-translate-y-1 hover:border-secondary/60 hover:shadow-lg"
@@ -200,7 +147,7 @@ export default function Page() {
             Rutinitas yang lembut dan konsisten membantu anak merasa aman sekaligus memupuk rasa tanggung jawab kecil.
           </p>
           <ul className="space-y-4">
-            {dailyRhythm.map((item, index) => (
+            {aboutDailyRhythm.map((item, index) => (
               <li
                 key={item.title}
                 className="group flex gap-4 rounded-2xl border border-transparent bg-white/80 p-4 transition-all duration-300 hover:-translate-y-1 hover:border-secondary/60 hover:shadow-lg"
@@ -228,7 +175,7 @@ export default function Page() {
             </p>
           </div>
           <div className="grid gap-6 md:grid-cols-3">
-            {strengths.map((item) => (
+            {aboutStrengths.map((item) => (
               <article
                 key={item.title}
                 className="card h-full space-y-3 p-7 transition-all duration-500 hover:-translate-y-1 hover:shadow-xl"
@@ -256,7 +203,7 @@ export default function Page() {
         <div className="card space-y-4 p-8 transition-all duration-500 hover:-translate-y-1 hover:shadow-xl">
           <h2 className="text-3xl font-semibold">Misi</h2>
           <ul className="space-y-3 text-base leading-relaxed text-text-muted">
-            {mission.map((point) => (
+            {aboutMission.map((point) => (
               <li
                 key={point}
                 className="rounded-2xl border border-transparent bg-white/80 p-4 transition-all duration-300 hover:-translate-y-1 hover:border-secondary/60 hover:shadow-lg"

--- a/tk-kartikasari/components/JsonLd.tsx
+++ b/tk-kartikasari/components/JsonLd.tsx
@@ -1,0 +1,18 @@
+import type { FC } from "react";
+
+type JsonLdProps = {
+  data: string | Record<string, unknown>;
+};
+
+const JsonLd: FC<JsonLdProps> = ({ data }) => {
+  const json = typeof data === "string" ? data : JSON.stringify(data);
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: json }}
+    />
+  );
+};
+
+export default JsonLd;

--- a/tk-kartikasari/components/home/HomePageContent.tsx
+++ b/tk-kartikasari/components/home/HomePageContent.tsx
@@ -1,50 +1,26 @@
 "use client";
 
 import CTAButton from "@/components/CTAButton";
-import StickyActions from "@/components/StickyActions";
 import TestimonialList from "@/components/TestimonialList";
 import PageSection from "@/components/layout/PageSection";
 import SectionHeader from "@/components/layout/SectionHeader";
 import type { CTAConfig } from "@/content/cta";
+import type {
+  HomeFaq,
+  HomeHighlight,
+  HomeJourneyItem,
+  HomeProgram,
+  HomeStat,
+} from "@/content/home";
 import { LazyMotion, domAnimation, m } from "framer-motion";
-
-type StatsItem = {
-  value: string;
-  label: string;
-};
-
-type HighlightItem = {
-  icon: string;
-  title: string;
-  description: string;
-};
-
-type ProgramItem = {
-  name: string;
-  age: string;
-  description: string;
-  points: string[];
-};
-
-type JourneyItem = {
-  time: string;
-  title: string;
-  description: string;
-  icon: string;
-};
-
-type FAQItem = {
-  question: string;
-  answer: string;
-};
 
 type HomePageContentProps = {
   schoolName: string;
-  stats: StatsItem[];
-  highlights: HighlightItem[];
-  programs: ProgramItem[];
-  journey: JourneyItem[];
-  faqs: FAQItem[];
+  stats: HomeStat[];
+  highlights: HomeHighlight[];
+  programs: HomeProgram[];
+  journey: HomeJourneyItem[];
+  faqs: HomeFaq[];
   heroCta: CTAConfig;
   faqCta: CTAConfig;
   visitCta: CTAConfig;
@@ -409,8 +385,6 @@ export default function HomePageContent({
             </div>
           </m.div>
         </PageSection>
-
-        <StickyActions />
       </>
     </LazyMotion>
   );

--- a/tk-kartikasari/content/about.ts
+++ b/tk-kartikasari/content/about.ts
@@ -1,0 +1,87 @@
+export type AboutHighlight = string;
+
+export type ExperiencePillar = {
+  title: string;
+  description: string;
+};
+
+export type DailyRhythmItem = {
+  title: string;
+  description: string;
+};
+
+export type StrengthItem = {
+  title: string;
+  description: string;
+};
+
+export const aboutMetaDescription =
+  "TK Kartikasari menghadirkan pendampingan personal, aktivitas tematik bermakna, dan kemitraan hangat dengan orang tua.";
+
+export const aboutHeaderHighlights: AboutHighlight[] = [
+  "Lingkungan aman & ramah anak",
+  "Guru komunikatif dengan orang tua",
+  "Belajar melalui bermain tematik",
+];
+
+export const aboutExperiencePillars: ExperiencePillar[] = [
+  {
+    title: "Hangat & Personal",
+    description:
+      "Guru menyapa anak satu per satu sambil mengenali kebiasaan, minat, dan kebutuhan unik mereka.",
+  },
+  {
+    title: "Aktivitas Bermakna",
+    description:
+      "Proyek tematik, bermain peran, dan eksplorasi alam menumbuhkan rasa percaya diri serta imajinasi.",
+  },
+  {
+    title: "Karakter Sehari-hari",
+    description:
+      "Nilai sopan santun, tanggung jawab, dan empati dipraktikkan melalui rutinitas sederhana yang menyenangkan.",
+  },
+];
+
+export const aboutDailyRhythm: DailyRhythmItem[] = [
+  {
+    title: "Sesi Pembuka yang Hangat",
+    description:
+      "Anak mengikuti doa, lagu, dan berbagi perasaan agar siap memulai hari dengan pikiran positif.",
+  },
+  {
+    title: "Eksplorasi Sentra & Outdoor",
+    description:
+      "Kegiatan berpindah antar sentra, eksperimen sains mini, dan bermain di luar menyalurkan energi anak.",
+  },
+  {
+    title: "Refleksi & Berbagi Cerita",
+    description:
+      "Anak diajak menceritakan penemuannya, merapikan alat, lalu menutup hari dengan lagu favorit bersama.",
+  },
+];
+
+export const aboutStrengths: StrengthItem[] = [
+  {
+    title: "Ruang Belajar Tematik",
+    description:
+      "Sentra literasi, sains mini, dan area seni memancing rasa ingin tahu sekaligus melatih motorik halus.",
+  },
+  {
+    title: "Rutinitas Penuh Makna",
+    description:
+      "Agenda harian menyeimbangkan kegiatan aktif dan tenang sehingga energi anak tetap stabil.",
+  },
+  {
+    title: "Kemitraan dengan Orang Tua",
+    description:
+      "Catatan perkembangan, foto kegiatan, dan temu wicara rutin menjaga keterlibatan keluarga.",
+  },
+];
+
+export const aboutMission: string[] = [
+  "Menumbuhkan rasa percaya diri, empati, dan kemandirian melalui kegiatan yang menyenangkan.",
+  "Menyediakan pengalaman tematik yang merangsang kreativitas, bahasa, dan numerasi awal.",
+  "Menguatkan kolaborasi guru dan orang tua melalui komunikasi harian yang bermakna.",
+  "Menghidupkan nilai moral, spiritual, dan cinta lingkungan dalam rutinitas anak.",
+  "Menciptakan lingkungan aman, bersih, dan inklusif yang menghargai keberagaman.",
+];

--- a/tk-kartikasari/content/home.ts
+++ b/tk-kartikasari/content/home.ts
@@ -1,0 +1,152 @@
+export type HomeStat = {
+  value: string;
+  label: string;
+};
+
+export type HomeHighlight = {
+  icon: string;
+  title: string;
+  description: string;
+};
+
+export type HomeProgram = {
+  name: string;
+  age: string;
+  description: string;
+  points: string[];
+};
+
+export type HomeJourneyItem = {
+  time: string;
+  title: string;
+  description: string;
+  icon: string;
+};
+
+export type HomeFaq = {
+  question: string;
+  answer: string;
+};
+
+export const homeHeroDescription =
+  "Lingkungan hangat, fasilitas aman, dan kegiatan tematik yang menumbuhkan rasa ingin tahu anak usia dini di Bantarsari, Cilacap.";
+
+export const homeStats: HomeStat[] = [
+  { value: "15+", label: "Tahun mendampingi anak Bulaksari" },
+  { value: "8", label: "Kegiatan tematik kreatif setiap minggu" },
+  { value: "100%", label: "Pendampingan perkembangan harian" },
+];
+
+export const homeHighlights: HomeHighlight[] = [
+  {
+    icon: "🎨",
+    title: "Belajar sambil berkarya",
+    description:
+      "Proyek seni, eksperimen sains sederhana, hingga dapur mini membuat anak senang bereksplorasi.",
+  },
+  {
+    icon: "🤝",
+    title: "Kolaborasi guru & orang tua",
+    description:
+      "Laporan perkembangan dikirim rutin dan kelas parenting singkat hadirkan tips mendampingi anak di rumah.",
+  },
+  {
+    icon: "🌱",
+    title: "Fokus karakter & kemandirian",
+    description:
+      "Rutinitas sederhana menumbuhkan rasa tanggung jawab, sopan santun, dan kepercayaan diri.",
+  },
+];
+
+export const homePrograms: HomeProgram[] = [
+  {
+    name: "Kelas Bintang",
+    age: "Usia 4-5 tahun",
+    description:
+      "Kurikulum bermain terpadu untuk mengenal huruf, angka, dan kemampuan sosial dasar.",
+    points: [
+      "Senam pagi dan circle time menyenangkan",
+      "Eksplorasi sensorik dan role play",
+      "Pengenalan literasi melalui cerita dan lagu",
+    ],
+  },
+  {
+    name: "Kelas Pelangi",
+    age: "Usia 5-6 tahun",
+    description:
+      "Persiapan menuju SD dengan proyek tematik dan kegiatan memecahkan masalah sederhana.",
+    points: [
+      "Proyek STEAM mingguan",
+      "Pembiasaan menulis dan berhitung ringan",
+      "Field trip edukatif ke lingkungan sekitar",
+    ],
+  },
+  {
+    name: "Ekstrakurikuler Ceria",
+    age: "Setiap Jumat",
+    description:
+      "Pilihan kelas tambahan seperti tari, tahfidz, dan kreativitas memasak untuk menyalurkan minat anak.",
+    points: [
+      "Dipandu instruktur ramah dan tersertifikasi",
+      "Pertunjukan kecil tiap akhir tema",
+      "Terbuka untuk kolaborasi dengan komunitas",
+    ],
+  },
+];
+
+export const homeJourney: HomeJourneyItem[] = [
+  {
+    time: "07.00",
+    title: "Penyambutan ceria",
+    description: "Guru menyapa anak satu per satu, memeriksa kesiapan, dan mengajak permainan ringan.",
+    icon: "🌞",
+  },
+  {
+    time: "08.00",
+    title: "Lingkar pagi",
+    description:
+      "Anak berbagi cerita, bernyanyi, dan belajar nilai moral sederhana bersama teman-teman.",
+    icon: "🗣️",
+  },
+  {
+    time: "09.00",
+    title: "Eksplorasi proyek",
+    description: "Setiap hari ada pusat kegiatan berbeda: seni, sains, balok, hingga dapur mini.",
+    icon: "🔍",
+  },
+  {
+    time: "10.30",
+    title: "Waktu luar ruang",
+    description: "Bermain di taman mini, berkebun, dan aktivitas motorik kasar secara aman dan terarah.",
+    icon: "🏃",
+  },
+  {
+    time: "11.30",
+    title: "Refleksi & doa",
+    description: "Anak merangkum pengalaman hari itu, membaca doa, lalu pulang dengan perasaan bahagia.",
+    icon: "🙏",
+  },
+];
+
+export const homeFaqs: HomeFaq[] = [
+  {
+    question: "Apa keunggulan utama TK Kartikasari?",
+    answer:
+      "Kami menghadirkan lingkungan belajar yang hangat, aman, dan kaya stimulasi. Guru-guru berpengalaman mendampingi anak dengan pendekatan personal agar setiap potensi tumbuh maksimal.",
+  },
+  {
+    question: "Bagaimana proses penerimaan peserta didik baru?",
+    answer:
+      "Cukup hubungi Bu Mintarsih melalui WhatsApp untuk jadwal observasi. Orang tua dapat mengisi formulir, konsultasi kebutuhan anak, lalu mengikuti sesi pengenalan kelas.",
+  },
+  {
+    question: "Apakah sekolah menyediakan laporan perkembangan?",
+    answer:
+      "Ya. Laporan harian singkat dibagikan lewat grup komunikasi, sedangkan laporan perkembangan lengkap diberikan setiap akhir tema dan semester.",
+  },
+  {
+    question: "Bagaimana keterlibatan orang tua di sekolah?",
+    answer:
+      "Kami rutin mengadakan kelas parenting singkat, hari kunjungan orang tua, dan kolaborasi proyek sehingga keluarga terlibat aktif dalam proses belajar anak.",
+  },
+];

--- a/tk-kartikasari/content/ppdb.ts
+++ b/tk-kartikasari/content/ppdb.ts
@@ -1,0 +1,39 @@
+export type PpdbStep = string;
+
+export type PpdbFaq = {
+  question: string;
+  answer: string;
+};
+
+export const ppdbMetaDescription =
+  "Ikuti langkah PPDB TK Kartikasari dan hubungi Ibu Mintarsih melalui WhatsApp untuk jadwal kunjungan serta konsultasi.";
+
+export const ppdbSteps: PpdbStep[] = [
+  "Hubungi Ibu Mintarsih melalui WhatsApp untuk mengatur jadwal kunjungan sekolah.",
+  "Datang ke TK Kartikasari sesuai jadwal yang disepakati untuk observasi singkat.",
+  "Lengkapi formulir data anak dan diskusi kebutuhan khusus bersama guru.",
+  "Lakukan pembayaran administrasi awal sesuai informasi dari sekolah.",
+];
+
+export const ppdbFaqs: PpdbFaq[] = [
+  {
+    question: "Kapan pendaftaran dibuka?",
+    answer:
+      "Pendaftaran dibuka sepanjang tahun ajaran berjalan. Kuota terbatas sehingga kami sarankan menghubungi sekolah lebih awal.",
+  },
+  {
+    question: "Dokumen apa saja yang perlu dibawa?",
+    answer:
+      "Fotokopi akta kelahiran anak, kartu keluarga, kartu identitas orang tua, dan buku imunisasi (jika ada).",
+  },
+  {
+    question: "Apakah ada biaya formulir?",
+    answer:
+      "Tidak ada biaya formulir. Pembayaran dilakukan setelah anak dinyatakan diterima dan menyepakati jadwal masuk.",
+  },
+  {
+    question: "Apakah ada program trial class?",
+    answer:
+      "Ada. Orang tua dapat meminta jadwal percobaan satu hari untuk memastikan anak nyaman sebelum resmi bergabung.",
+  },
+];

--- a/tk-kartikasari/content/programs.ts
+++ b/tk-kartikasari/content/programs.ts
@@ -1,0 +1,96 @@
+export type ProgramClass = {
+  name: string;
+  age: string;
+  description: string;
+  focus: string[];
+};
+
+export type LearningMethod = {
+  title: string;
+  description: string;
+};
+
+export type WeeklyScheduleItem = {
+  day: string;
+  theme: string;
+  highlight: string;
+};
+
+export const programsMetaDescription =
+  "Program TK Kartikasari memadukan eksplorasi sensorik, literasi awal, dan aktivitas STEAM sederhana untuk menumbuhkan karakter.";
+
+export const programClasses: ProgramClass[] = [
+  {
+    name: "Kelas A • Bintang Kecil",
+    age: "Usia 4–5 tahun",
+    description:
+      "Masa peralihan dari playgroup menuju TK yang fokus pada eksplorasi sensorik, bahasa awal, dan kemandirian sederhana.",
+    focus: [
+      "Pembiasaan rutinitas dan sopan santun sehari-hari",
+      "Koordinasi motorik halus melalui aktivitas seni dan konstruksi",
+      "Pengayaan kosa kata lewat cerita, lagu, dan permainan peran",
+    ],
+  },
+  {
+    name: "Kelas B • Pelangi Ceria",
+    age: "Usia 5–6 tahun",
+    description:
+      "Persiapan menuju sekolah dasar dengan penguatan literasi, numerasi, dan kemampuan sosial memimpin kelompok.",
+    focus: [
+      "Eksperimen STEAM sederhana dan proyek tematik mingguan",
+      "Pembiasaan menulis nama, membaca suku kata, dan berhitung konkret",
+      "Latihan presentasi mini untuk membangun rasa percaya diri",
+    ],
+  },
+];
+
+export const programLearningMethods: LearningMethod[] = [
+  {
+    title: "Sentra tematik",
+    description:
+      "Setiap hari anak bergiliran di sentra seni, balok, main peran, sains, dan persiapan agar pengalaman belajar kaya dan seimbang.",
+  },
+  {
+    title: "Pendampingan individual",
+    description:
+      "Guru melakukan observasi harian dan catatan perkembangan sehingga kebutuhan masing-masing anak dapat ditindaklanjuti.",
+  },
+  {
+    title: "Kolaborasi orang tua",
+    description:
+      "Laporan kegiatan dibagikan melalui WhatsApp dan sesi konsultasi bulanan untuk menyepakati strategi di rumah.",
+  },
+  {
+    title: "Belajar di luar ruang",
+    description:
+      "Kegiatan berkebun, senam irama, dan eksplorasi lingkungan sekitar menyeimbangkan stimulasi fisik dan sosial anak.",
+  },
+];
+
+export const programWeeklySchedule: WeeklyScheduleItem[] = [
+  {
+    day: "Senin",
+    theme: "Pembukaan tema & circle time",
+    highlight: "Senam pagi, diskusi nilai moral, dan pengenalan kosa kata baru.",
+  },
+  {
+    day: "Selasa",
+    theme: "Eksperimen & sains sederhana",
+    highlight: "Percobaan warna, air, atau alam yang memantik rasa ingin tahu.",
+  },
+  {
+    day: "Rabu",
+    theme: "Karya kreatif",
+    highlight: "Melukis, kolase, hingga dapur mini untuk melatih motorik halus.",
+  },
+  {
+    day: "Kamis",
+    theme: "Berhitung dan literasi awal",
+    highlight: "Permainan angka, pengenalan huruf, dan membaca cerita interaktif.",
+  },
+  {
+    day: "Jumat",
+    theme: "Eksplorasi luar ruang & ekstrakurikuler",
+    highlight: "Berkebun, bermain peran, serta pilihan kelas tari, tahfidz, atau musik.",
+  },
+];

--- a/tk-kartikasari/data/site.json
+++ b/tk-kartikasari/data/site.json
@@ -1,5 +1,6 @@
 {
   "schoolName": "TK Kartikasari",
+  "siteUrl": "https://tk-kartikasari.sch.id",
   "address": "Jl. K.H. Syarbini Hasan No.2, Sidadadi, Bulaksari, Kec. Bantarsari, Kabupaten Cilacap, Jawa Tengah 53258",
   "whatsapp": "085227227826",
   "headmaster": "Ibu Mintarsih",

--- a/tk-kartikasari/docs/architecture-migration.md
+++ b/tk-kartikasari/docs/architecture-migration.md
@@ -1,0 +1,97 @@
+# Architecture Migration Plan: From Single-Page Static Site to Multi-Page Next.js App
+
+## 1. Objectives & Success Criteria
+- Deliver a modern multi-page experience that improves organic discovery through per-page metadata and structured content.
+- Support clearer content organization so families can easily find information about TK Kartikasari's programs, admissions, and activities.
+- Enhance navigation and conversion flows via dedicated pages and context-aware CTAs.
+- Ensure the site can scale for future content updates without major rewrites.
+
+**Key benefits of the migration**
+1. Better SEO with page-level optimization (Open Graph, schema, structured data).
+2. Improved content organization by separating concerns per route.
+3. Enhanced user navigation through reusable layout, sticky CTAs, and sitemap alignment.
+4. Scalable content management by externalizing copy, media, and structured data.
+
+## 2. Target Architecture Overview
+- **Framework**: Next.js 14 App Router with React Server Components for fast, SEO-friendly pages.
+- **Rendering strategy**: Static Site Generation (SSG) for public content with optional Incremental Static Regeneration (ISR) to refresh agenda/pengumuman data without full redeploys.
+- **Routing model**: Nested routes using the `app/` directory (e.g., `app/tentang/page.tsx`, `app/program/page.tsx`) with a shared `app/layout.tsx` for global theming, meta, and navigation.
+- **Component system**: Consolidate UI patterns in `components/` (hero, testimonials, navigation, cards) to keep pages declarative.
+- **Content layer**: Store structured data in `data/*.json` (agenda, pengumuman, galeri, testimonials, site metadata) and exported helper content in `content/`. Migrate ad-hoc copy into these sources to decouple presentation from content.
+- **Styling**: Continue Tailwind CSS via `app/globals.css` and `tailwind.config.js`, leveraging utility classes for rapid iteration.
+- **SEO utilities**: Centralize schema definitions in `lib/schema.ts` and expose a helper to inject JSON-LD per page. Use Next.js Metadata API for dynamic titles/descriptions.
+
+## 3. Information Architecture & Sitemap
+| Page | Route | Content Source | Notes |
+| --- | --- | --- | --- |
+| Beranda | `/` | Hero, stats, FAQ, CTA content from `components/home` and `data/site.json` | Showcase differentiators, testimonials, WhatsApp CTA.
+| Tentang | `/tentang` | Narrative sections sourced from JSON / markdown | Highlight vision, educator profiles, facility photos.
+| Program | `/program` | Program list from `data/site.json` (or future CMS) | Provide detailed curriculum breakdown per usia.
+| PPDB | `/ppdb` | Step-by-step admissions data from JSON | Embed forms/CTA using `content/cta.ts` exports.
+| Pengumuman | `/pengumuman` | Structured list from `data/pengumuman.json` | Support ISR when integrated with CMS.
+| Agenda | `/agenda` | Events from `data/agenda.json` | Use chronological grouping and filters.
+| Galeri | `/galeri` | Gallery items from `data/galeri.json` with images stored in `public/photos` | Optimize images via `next/image`.
+| Kontak | `/kontak` | Contact methods and map embed from JSON | Include persistent CTA.
+
+## 4. Migration Strategy
+1. **Audit & content extraction**
+   - Inventory sections in the current single-page site and map each to the target route above.
+   - Externalize copy and list data into JSON/TypeScript modules inside `data/` or `content/`.
+2. **Bootstrap Next.js foundation**
+   - Initialize Next.js App Router project (already present in this repository) with TypeScript, Tailwind, and linting.
+   - Configure shared layout, navigation (`data/navigation.ts`), and footer.
+3. **Implement page shells**
+   - Create `app/{route}/page.tsx` files rendering page-level components.
+   - Wire metadata via `generateMetadata` for titles, descriptions, and canonical URLs.
+4. **Componentize shared UI**
+   - Port sections into reusable components within `components/` (hero, CTA blocks, testimonials, agenda list, cards).
+   - Add motion enhancements with `framer-motion` where needed for interactivity.
+5. **Data binding & dynamic content**
+   - Replace hardcoded strings with data imports (e.g., agenda, announcements, testimonials).
+   - Prepare adapters for future CMS integration (contentful, Sanity, or simple CMS) while defaulting to local JSON.
+6. **Navigation & conversion flows**
+   - Implement top navigation, sticky CTA bar, and context-specific actions using data from `content/cta.ts`.
+   - Ensure WhatsApp CTA and Directions CTA persist across pages using the shared layout.
+7. **SEO, analytics, and performance**
+   - Inject structured data via helpers in `lib/schema.ts`.
+   - Configure per-page Open Graph images and meta tags.
+   - Add analytics snippet (e.g., Google Analytics) via Next.js `head` management if required.
+8. **Testing & launch**
+   - Validate responsive design across key breakpoints.
+   - Run automated accessibility and Lighthouse audits.
+   - Use `next build` and preview deployment before cut-over.
+
+## 5. Content Management & Scalability
+- Define a clear contract for data objects in `data/*.json` to enable validation.
+- Introduce Zod or TypeScript types to guard against malformed content when scaling contributors.
+- Plan for optional CMS integration by encapsulating data fetching in utility functions (e.g., `lib/api.ts`).
+- Organize media assets under `public/photos` with consistent naming; adopt `next/image` for optimization.
+
+## 6. Non-Functional Requirements
+- **Performance**: Aim for <1s Largest Contentful Paint on 4G, leverage image optimization and static generation.
+- **Accessibility**: Use semantic HTML, focus states, aria labels, and test with screen readers.
+- **Internationalization** (optional future): Structure content to allow locale keys if bilingual site is needed.
+- **Security**: Enforce HTTPS redirects and security headers during deployment (Vercel or equivalent).
+
+## 7. Risks & Mitigation
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Content drift between JSON and actual sections | Medium | Document content owners and editing workflow; add content validation step in CI. |
+| SEO regression during cut-over | High | Launch on staging domain, crawl for broken links, submit updated sitemap to Google. |
+| Limited internal familiarity with Next.js | Medium | Pair programming sessions, provide code walkthroughs, add README instructions. |
+| Asset optimization backlog | Low | Schedule dedicated task to compress and convert gallery images to `.webp`. |
+
+## 8. Implementation Roadmap (6–8 weeks)
+1. Week 1: Content audit, sitemap sign-off, Next.js foundation review.
+2. Weeks 2-3: Build page shells and shared layout/navigation.
+3. Weeks 3-4: Component extraction, data binding, integrate CTAs.
+4. Week 5: SEO setup, structured data, analytics, performance tuning.
+5. Week 6: QA (responsive, accessibility, Lighthouse), content freeze.
+6. Weeks 7-8: Optional CMS adapter, stakeholder review, production launch & monitoring.
+
+## 9. Definition of Done
+- All key routes (`/`, `/tentang`, `/program`, `/ppdb`, `/pengumuman`, `/agenda`, `/galeri`, `/kontak`) implemented with dedicated content.
+- Shared layout delivers consistent navigation and CTAs across pages.
+- Page-level metadata, schema, and Open Graph tags configured.
+- Content stored in structured sources with documented update workflow.
+- `next build` passes without errors and deployment preview validated by stakeholders.

--- a/tk-kartikasari/lib/metadata.ts
+++ b/tk-kartikasari/lib/metadata.ts
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+
+import site from "@/data/site.json";
+
+type MetadataOptions = {
+  title: string;
+  description: string;
+  path: string;
+};
+
+export function createPageMetadata({ title, description, path }: MetadataOptions): Metadata {
+  const url = new URL(path, site.siteUrl).toString();
+  const fullTitle = `${title} | ${site.schoolName}`;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: url,
+    },
+    openGraph: {
+      title: fullTitle,
+      description,
+      url,
+      siteName: site.schoolName,
+      type: "website",
+      locale: "id_ID",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: fullTitle,
+      description,
+    },
+  };
+}

--- a/tk-kartikasari/lib/schema.ts
+++ b/tk-kartikasari/lib/schema.ts
@@ -1,21 +1,48 @@
-import site from '@/data/site.json'
+import site from "@/data/site.json";
 
 export function preschoolSchema(lat?: number, lng?: number) {
-  const jsonLd: any = {
-    '@context': 'https://schema.org',
-    '@type': 'Preschool',
+  const jsonLd: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Preschool",
+    "@id": `${site.siteUrl}#organization`,
     name: site.schoolName,
-    address: {
-      '@type': 'PostalAddress',
-      streetAddress: site.address,
-      addressLocality: 'Bantarsari',
-      addressRegion: 'Jawa Tengah',
-      postalCode: '53258',
-      addressCountry: 'ID',
-    },
+    description:
+      "Taman Kanak-kanak di Bulaksari, Bantarsari, Cilacap dengan lingkungan hangat dan kegiatan tematik.",
+    url: site.siteUrl,
     telephone: site.whatsapp,
-    url: 'https://example.com',
+    hasMap: site.mapsUrl,
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: site.address,
+      addressLocality: "Bantarsari",
+      addressRegion: "Jawa Tengah",
+      postalCode: "53258",
+      addressCountry: "ID",
+    },
+    openingHoursSpecification: [
+      {
+        "@type": "OpeningHoursSpecification",
+        dayOfWeek: [
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday",
+        ],
+        opens: "07:00",
+        closes: "13:00",
+      },
+    ],
+  };
+
+  if (lat && lng) {
+    jsonLd.geo = {
+      "@type": "GeoCoordinates",
+      latitude: lat,
+      longitude: lng,
+    };
   }
-  if (lat && lng) jsonLd.geo = { '@type': 'GeoCoordinates', latitude: lat, longitude: lng }
-  return JSON.stringify(jsonLd)
+
+  return JSON.stringify(jsonLd);
 }


### PR DESCRIPTION
## Summary
- centralize homepage, about, program, and PPDB copy in typed content modules to simplify structured data updates
- add a reusable metadata helper and apply canonical/Open Graph settings across every route plus the global layout
- expose preschool JSON-LD schema and move the sticky WhatsApp CTA into the root layout to support the migration plan

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2d437ef90832faa56dcb47912c69a