### PR TITLE
Hide sticky actions on small screens

### DIFF
--- a/tk-kartikasari/components/StickyActions.tsx
+++ b/tk-kartikasari/components/StickyActions.tsx
@@ -6,7 +6,7 @@ import site from "@/data/site.json";
 
 export default function StickyActions() {
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 pb-[calc(env(safe-area-inset-bottom,0)+1.5rem)]">
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 hidden pb-[calc(env(safe-area-inset-bottom,0)+1.5rem)] md:block">
       <div className="container pointer-events-auto">
         <div className="flex flex-col gap-4 rounded-3xl border border-border/70 bg-surface/95 px-5 py-5 shadow-soft backdrop-blur sm:flex-row sm:items-center sm:justify-between">
           <div>


### PR DESCRIPTION
## Summary
- hide the sticky WhatsApp/directions bar on viewports smaller than the md breakpoint
- prevent the fixed bar from obstructing mobile content while keeping desktop access

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2dc6c9e08832f80838b88460d742c