### PR TITLE
Enhance frosted surfaces and mobile navigation

### DIFF
--- a/tk-kartikasari/app/globals.css
+++ b/tk-kartikasari/app/globals.css
@@ -50,7 +50,7 @@ body {
 }
 
 .btn-outline {
-  @apply btn border border-border/80 bg-white/80 text-text hover:border-primary hover:text-primary;
+  @apply btn border border-white/60 bg-white/60 text-text backdrop-blur-sm hover:border-primary hover:bg-white/70 hover:text-primary;
 }
 
 .input {

--- a/tk-kartikasari/app/layout.tsx
+++ b/tk-kartikasari/app/layout.tsx
@@ -40,14 +40,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="id">
       <body className="bg-surfaceAlt text-text font-sans">
         <div className="relative min-h-screen">
-          <header className="sticky top-0 z-50 border-b border-white/60 bg-white/90 shadow-sm backdrop-blur">
+          <header className="sticky top-0 z-50 border-b border-white/40 bg-white/60 shadow-lg backdrop-blur-xl backdrop-saturate-150">
             <div className="container">
               <div className="relative flex w-full items-center gap-3 py-3 md:gap-5 md:py-4">
                 <Link
                   href="/"
                   className="flex shrink-0 items-center gap-3 text-text transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
                 >
-                  <span className="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/70 bg-white shadow-soft">
+                  <span className="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/60 bg-white/70 shadow-soft backdrop-blur-sm">
                     <img src={site.logo} alt="Logo TK Kartikasari" className="h-8 w-8 object-contain" />
                   </span>
                   <span className="flex min-w-0 flex-col leading-tight">

--- a/tk-kartikasari/app/tentang/page.tsx
+++ b/tk-kartikasari/app/tentang/page.tsx
@@ -45,7 +45,7 @@ export default function Page() {
           {aboutHeaderHighlights.map((item) => (
             <span
               key={item}
-              className="inline-flex items-center gap-2 rounded-full border border-secondary/40 bg-white/80 px-4 py-2 text-sm font-medium text-secondary transition-all duration-300 hover:-translate-y-0.5 hover:border-secondary hover:bg-secondary/10"
+              className="inline-flex items-center gap-2 rounded-full border border-secondary/50 bg-white/60 px-4 py-2 text-sm font-medium text-secondary backdrop-blur-sm backdrop-saturate-150 transition-all duration-300 hover:-translate-y-0.5 hover:border-secondary hover:bg-secondary/10"
             >
               <span className="h-2 w-2 rounded-full bg-secondary" aria-hidden="true" />
               {item}
@@ -81,7 +81,7 @@ export default function Page() {
               {aboutExperiencePillars.map((pillar) => (
                 <li
                   key={pillar.title}
-                  className="group relative overflow-hidden rounded-2xl border border-white/50 bg-white/80 p-4 transition-all duration-300 hover:-translate-y-1 hover:border-secondary/60 hover:shadow-lg"
+                  className="group relative overflow-hidden rounded-2xl border border-white/60 bg-white/60 p-4 transition-all duration-300 backdrop-blur-lg backdrop-saturate-150 hover:-translate-y-1 hover:border-secondary/60 hover:shadow-lg"
                 >
                   <span className="mb-2 inline-flex rounded-full bg-secondary/10 px-3 py-1 text-xs font-semibold text-secondary transition-colors duration-300 group-hover:bg-secondary group-hover:text-white">
                     {pillar.title}
@@ -133,7 +133,7 @@ export default function Page() {
             {profileItems.map((item) => (
               <li
                 key={item.label}
-                className="rounded-2xl border border-border/60 bg-white/90 p-5 transition-all duration-300 hover:-translate-y-1 hover:border-secondary hover:shadow-lg"
+                className="rounded-2xl border border-white/60 bg-white/60 p-5 transition-all duration-300 backdrop-blur-lg backdrop-saturate-150 hover:-translate-y-1 hover:border-secondary hover:shadow-lg"
               >
                 <p className="text-xs uppercase tracking-wide text-secondary">{item.label}</p>
                 <p className="mt-1 text-base font-medium text-text">{item.value}</p>
@@ -150,7 +150,7 @@ export default function Page() {
             {aboutDailyRhythm.map((item, index) => (
               <li
                 key={item.title}
-                className="group flex gap-4 rounded-2xl border border-transparent bg-white/80 p-4 transition-all duration-300 hover:-translate-y-1 hover:border-secondary/60 hover:shadow-lg"
+                className="group flex gap-4 rounded-2xl border border-white/60 bg-white/60 p-4 transition-all duration-300 backdrop-blur-lg backdrop-saturate-150 hover:-translate-y-1 hover:border-secondary/60 hover:shadow-lg"
               >
                 <span className="flex h-10 w-10 items-center justify-center rounded-full bg-secondary/10 text-sm font-semibold text-secondary transition-colors duration-300 group-hover:bg-secondary group-hover:text-white">
                   {String(index + 1).padStart(2, "0")}
@@ -206,7 +206,7 @@ export default function Page() {
             {aboutMission.map((point) => (
               <li
                 key={point}
-                className="rounded-2xl border border-transparent bg-white/80 p-4 transition-all duration-300 hover:-translate-y-1 hover:border-secondary/60 hover:shadow-lg"
+                className="rounded-2xl border border-white/60 bg-white/60 p-4 transition-all duration-300 backdrop-blur-lg backdrop-saturate-150 hover:-translate-y-1 hover:border-secondary/60 hover:shadow-lg"
               >
                 {point}
               </li>
@@ -231,7 +231,7 @@ export default function Page() {
               </Link>
               <Link
                 href="/kontak"
-                className="btn-outline border-white/80 bg-white/20 text-white hover:border-white hover:bg-white hover:text-secondary"
+                className="btn-outline border-white/70 bg-white/30 text-white backdrop-saturate-150 hover:border-white hover:bg-white/40 hover:text-secondary"
               >
                 Jadwalkan Kunjungan
               </Link>

--- a/tk-kartikasari/components/CTAButton.tsx
+++ b/tk-kartikasari/components/CTAButton.tsx
@@ -46,7 +46,7 @@ export default function CTAButton({
   return (
     <a href={waLink(finalMessage)} className={classes}>
       <span className="flex items-center gap-3">
-        <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/20 text-white transition group-hover:bg-white/30">
+        <span className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/50 bg-white/20 text-white backdrop-blur-sm backdrop-saturate-150 transition group-hover:bg-white/30">
           <svg
             width="20"
             height="20"

--- a/tk-kartikasari/components/MobileNav.tsx
+++ b/tk-kartikasari/components/MobileNav.tsx
@@ -4,8 +4,40 @@ import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
+import type { Variants } from "framer-motion";
 
 import { mainNav } from "@/data/navigation";
+
+const menuVariants: Variants = {
+  hidden: {
+    opacity: 0,
+    y: -16,
+    scale: 0.96,
+    filter: "blur(12px)",
+  },
+  visible: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    filter: "blur(0px)",
+    transition: {
+      type: "spring",
+      stiffness: 220,
+      damping: 22,
+      mass: 0.9,
+    },
+  },
+  exit: {
+    opacity: 0,
+    y: -12,
+    scale: 0.98,
+    filter: "blur(8px)",
+    transition: {
+      duration: 0.18,
+      ease: "easeInOut",
+    },
+  },
+};
 
 export default function MobileNav() {
   const [open, setOpen] = useState(false);
@@ -20,7 +52,7 @@ export default function MobileNav() {
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
         aria-controls="mobile-nav"
-        className="inline-flex items-center justify-center rounded-full border border-border/70 bg-white/90 p-2.5 text-text shadow-soft transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        className="inline-flex items-center justify-center rounded-full border border-white/60 bg-white/50 p-2.5 text-text shadow-soft backdrop-blur-sm backdrop-saturate-150 transition hover:border-primary hover:bg-white/60 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
         whileTap={{ scale: 0.95 }}
       >
         <span className="sr-only">Toggle navigation</span>
@@ -45,33 +77,42 @@ export default function MobileNav() {
       <AnimatePresence>
         {open ? (
           <motion.div
+            key="mobile-nav"
             id="mobile-nav"
-            className="absolute left-0 right-0 top-[calc(100%+0.75rem)] z-50 rounded-3xl border border-border/70 bg-white/95 p-4 shadow-xl backdrop-blur"
-            initial={{ opacity: 0, y: -8 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -8 }}
-            transition={{ duration: 0.2, ease: "easeOut" }}
+            className="absolute left-0 right-0 top-[calc(100%+0.75rem)] z-50 overflow-hidden rounded-3xl border border-white/50 bg-white/60 p-4 shadow-2xl backdrop-blur-xl backdrop-saturate-150"
+            variants={menuVariants}
+            initial="hidden"
+            animate="visible"
+            exit="exit"
+            style={{ transformOrigin: "top center" }}
           >
             <nav className="flex flex-col gap-1 text-base font-medium text-text">
-              {mainNav.map((item) => {
+              {mainNav.map((item, index) => {
                 const isActive =
                   item.href === "/"
                     ? pathname === "/"
                     : pathname === item.href || pathname.startsWith(`${item.href}/`);
                 return (
-                  <Link
+                  <motion.div
                     key={item.href}
-                    href={item.href}
-                    onClick={closeMenu}
-                    aria-current={isActive ? "page" : undefined}
-                    className={`block rounded-full px-4 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
-                      isActive
-                        ? "bg-primary/10 text-primary"
-                        : "text-text-muted hover:bg-surfaceAlt hover:text-text"
-                    }`}
+                    initial={{ opacity: 0, y: -6 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -6 }}
+                    transition={{ duration: 0.22, delay: 0.08 + index * 0.04, ease: "easeOut" }}
                   >
-                    {item.label}
-                  </Link>
+                    <Link
+                      href={item.href}
+                      onClick={closeMenu}
+                      aria-current={isActive ? "page" : undefined}
+                      className={`block rounded-full px-4 py-2 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
+                        isActive
+                          ? "bg-primary/10 text-primary"
+                          : "text-text-muted hover:bg-white/60 hover:text-text"
+                      }`}
+                    >
+                      {item.label}
+                    </Link>
+                  </motion.div>
                 );
               })}
             </nav>

--- a/tk-kartikasari/components/home/HomePageContent.tsx
+++ b/tk-kartikasari/components/home/HomePageContent.tsx
@@ -56,7 +56,7 @@ export default function HomePageContent({
             transition={{ duration: 0.6 }}
             className="relative space-y-8"
           >
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/80 px-4 py-2 text-sm font-semibold text-secondary shadow-soft">
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/60 px-4 py-2 text-sm font-semibold text-secondary shadow-soft backdrop-blur-sm backdrop-saturate-150">
               <span className="h-2.5 w-2.5 rounded-full bg-secondary" />
               {schoolName} • Bulaksari
             </span>
@@ -76,7 +76,7 @@ export default function HomePageContent({
               {stats.map((item) => (
                 <div
                   key={item.label}
-                  className="rounded-3xl border border-white/60 bg-white/80 p-5 text-left shadow-soft"
+                  className="rounded-3xl border border-white/60 bg-white/60 p-5 text-left shadow-soft backdrop-blur-lg backdrop-saturate-150"
                 >
                   <dt className="text-3xl font-bold text-text">{item.value}</dt>
                   <dd className="mt-1 text-base text-text-muted">{item.label}</dd>
@@ -94,7 +94,7 @@ export default function HomePageContent({
             <div className="absolute -top-12 right-10 h-32 w-32 rounded-full bg-accent/40 blur-2xl" />
             <div className="absolute -bottom-4 left-0 h-28 w-28 rounded-full bg-secondary/30 blur-2xl md:-bottom-8" />
             <div className="relative space-y-5">
-              <div className="card overflow-hidden border-white/60 bg-white/90 p-6 shadow-soft">
+              <div className="card overflow-hidden border-white/60 bg-white/70 p-6 shadow-soft backdrop-blur-xl backdrop-saturate-150">
                 <div className="flex items-center justify-between text-base font-semibold text-text">
                   <span>Agenda Hari Ini</span>
                   <span className="rounded-full bg-secondary/10 px-3 py-1 text-sm font-semibold text-secondary">
@@ -122,7 +122,7 @@ export default function HomePageContent({
                   </li>
                 </ul>
               </div>
-              <div className="ml-auto w-[85%] rounded-3xl border border-white/60 bg-white/70 p-6 shadow-soft backdrop-blur">
+              <div className="ml-auto w-[85%] rounded-3xl border border-white/60 bg-white/50 p-6 shadow-soft backdrop-blur-xl backdrop-saturate-150">
                 <p className="text-base font-semibold text-secondary">Lingkungan Aman</p>
                 <p className="mt-3 text-base leading-relaxed text-text-muted">
                   Semua area belajar dipantau CCTV, dilengkapi akses kontrol, serta peralatan ramah anak.
@@ -135,13 +135,13 @@ export default function HomePageContent({
                 </div>
               </div>
               <div className="grid gap-4 sm:grid-cols-2">
-                <div className="rounded-3xl border border-white/60 bg-white/90 p-5 shadow-soft">
+                <div className="rounded-3xl border border-white/60 bg-white/60 p-5 shadow-soft backdrop-blur-lg backdrop-saturate-150">
                   <p className="text-base font-semibold text-secondary">Fokus Harian</p>
                   <p className="mt-2 text-base text-text-muted">
                     Motorik, bahasa, sosial-emosi, dan kemandirian.
                   </p>
                 </div>
-                <div className="rounded-3xl border border-white/60 bg-white/90 p-5 shadow-soft">
+                <div className="rounded-3xl border border-white/60 bg-white/60 p-5 shadow-soft backdrop-blur-lg backdrop-saturate-150">
                   <p className="text-base font-semibold text-secondary">Menu Sehat</p>
                   <p className="mt-2 text-base text-text-muted">
                     Snack buah segar & susu rendah gula.
@@ -153,7 +153,7 @@ export default function HomePageContent({
         </PageSection>
 
         <PageSection
-          className="relative border-y border-white/60 bg-white/80"
+          className="relative border-y border-white/50 bg-white/50 backdrop-blur-sm backdrop-saturate-150"
           padding="tight"
         >
           <m.div
@@ -178,7 +178,7 @@ export default function HomePageContent({
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, amount: 0.3 }}
                 transition={{ duration: 0.55, delay: index * 0.08 }}
-                className="card h-full border-white/60 bg-white/90 p-7 text-left"
+                className="card h-full border-white/60 bg-white/70 p-7 text-left backdrop-blur-xl backdrop-saturate-150"
               >
                 <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/15 text-2xl">
                   {item.icon}
@@ -237,7 +237,7 @@ export default function HomePageContent({
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, amount: 0.3 }}
                 transition={{ duration: 0.55, delay: index * 0.08 }}
-                className="card h-full border-white/70 bg-white/90 p-7 shadow-soft"
+                className="card h-full border-white/70 bg-white/70 p-7 shadow-soft backdrop-blur-xl backdrop-saturate-150"
               >
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                   <div className="space-y-3">
@@ -288,7 +288,7 @@ export default function HomePageContent({
               title="Jadwal penuh aktivitas yang menstimulasi seluruh aspek perkembangan anak"
               description="Guru kami menyiapkan transisi yang mulus dari aktivitas indoor ke outdoor sehingga anak tetap bersemangat hingga waktu pulang."
             />
-            <div className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-soft">
+            <div className="rounded-3xl border border-white/60 bg-white/60 p-6 shadow-soft backdrop-blur-lg backdrop-saturate-150">
               <p className="text-base font-semibold text-secondary">Kolaborasi dengan orang tua</p>
               <p className="mt-3 text-base leading-relaxed text-text-muted">
                 Orang tua mendapatkan ringkasan kegiatan dan foto terbaik anak setiap hari melalui kanal komunikasi khusus.
@@ -303,7 +303,7 @@ export default function HomePageContent({
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, amount: 0.3 }}
                 transition={{ duration: 0.5, delay: index * 0.05 }}
-                className="grid gap-4 rounded-3xl border border-white/60 bg-white/85 p-6 shadow-soft sm:grid-cols-[auto,1fr] sm:items-center"
+                className="grid gap-4 rounded-3xl border border-white/60 bg-white/60 p-6 shadow-soft backdrop-blur-lg backdrop-saturate-150 sm:grid-cols-[auto,1fr] sm:items-center"
               >
                 <div className="flex items-center gap-3">
                   <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-secondary/10 text-2xl">
@@ -349,7 +349,7 @@ export default function HomePageContent({
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, amount: 0.3 }}
                 transition={{ duration: 0.55, delay: index * 0.08 }}
-                className="card border-white/70 bg-white/90 p-6 text-left shadow-soft"
+                className="card border-white/70 bg-white/70 p-6 text-left shadow-soft backdrop-blur-xl backdrop-saturate-150"
               >
                 <p className="text-lg font-semibold text-text">{faq.question}</p>
                 <p className="mt-3 text-base leading-relaxed text-text-muted">{faq.answer}</p>
@@ -367,7 +367,7 @@ export default function HomePageContent({
             className="card flex flex-col gap-6 overflow-hidden border-white/70 bg-gradient-to-br from-secondary/10 via-white to-primary/10 p-10 text-center md:flex-row md:items-center md:justify-between md:text-left"
           >
             <div className="max-w-xl space-y-4">
-              <span className="inline-flex items-center gap-2 rounded-full bg-white/70 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-secondary">
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/60 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-secondary backdrop-blur-sm backdrop-saturate-150">
                 Siap bergabung
               </span>
               <h2 className="text-balance text-3xl font-semibold text-text sm:text-4xl">

--- a/tk-kartikasari/components/layout/SectionHeader.tsx
+++ b/tk-kartikasari/components/layout/SectionHeader.tsx
@@ -16,7 +16,7 @@ type SectionHeaderProps = {
 const eyebrowStyles: Record<NonNullable<SectionHeaderProps["eyebrowVariant"]>, string> = {
   primary: "bg-primary/15 text-primary",
   secondary: "bg-secondary/15 text-secondary",
-  surface: "bg-white/80 text-secondary",
+  surface: "border border-white/60 bg-white/60 text-secondary backdrop-blur-sm backdrop-saturate-150",
   muted: "bg-border/40 text-text",
 };
 


### PR DESCRIPTION
## Summary
- polish the header, buttons, and global glassmorphism tokens to use lighter translucent backgrounds with backdrop blur
- refresh hero, program, FAQ, and about-page cards and badges with consistent frosted styling and CTA icon framing
- redesign the mobile navigation dropdown with spring-driven animation and a saturated blurred panel for an Apple-like feel

## Testing
- npm run lint
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d2e11322f4832f97c08bf8893fd9d3