### PR TITLE
Improve mobile nav backdrop

### DIFF
--- a/tk-kartikasari/components/MobileNav.tsx
+++ b/tk-kartikasari/components/MobileNav.tsx
@@ -46,13 +46,13 @@ export default function MobileNav() {
   const closeMenu = () => setOpen(false);
 
   return (
-    <div className="lg:hidden">
+    <div className="relative lg:hidden">
       <motion.button
         type="button"
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
         aria-controls="mobile-nav"
-        className="inline-flex items-center justify-center rounded-full border border-white/60 bg-white/50 p-2.5 text-text shadow-soft backdrop-blur-sm backdrop-saturate-150 transition hover:border-primary hover:bg-white/60 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        className="relative z-50 inline-flex items-center justify-center rounded-full border border-white/60 bg-white/50 p-2.5 text-text shadow-soft backdrop-blur-sm backdrop-saturate-150 transition hover:border-primary hover:bg-white/60 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
         whileTap={{ scale: 0.95 }}
       >
         <span className="sr-only">Toggle navigation</span>
@@ -76,47 +76,58 @@ export default function MobileNav() {
       </motion.button>
       <AnimatePresence>
         {open ? (
-          <motion.div
-            key="mobile-nav"
-            id="mobile-nav"
-            className="absolute left-0 right-0 top-[calc(100%+0.75rem)] z-50 overflow-hidden rounded-3xl border border-white/50 bg-white/60 p-4 shadow-2xl backdrop-blur-xl backdrop-saturate-150"
-            variants={menuVariants}
-            initial="hidden"
-            animate="visible"
-            exit="exit"
-            style={{ transformOrigin: "top center" }}
-          >
-            <nav className="flex flex-col gap-1 text-base font-medium text-text">
-              {mainNav.map((item, index) => {
-                const isActive =
-                  item.href === "/"
-                    ? pathname === "/"
-                    : pathname === item.href || pathname.startsWith(`${item.href}/`);
-                return (
-                  <motion.div
-                    key={item.href}
-                    initial={{ opacity: 0, y: -6 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -6 }}
-                    transition={{ duration: 0.22, delay: 0.08 + index * 0.04, ease: "easeOut" }}
-                  >
-                    <Link
-                      href={item.href}
-                      onClick={closeMenu}
-                      aria-current={isActive ? "page" : undefined}
-                      className={`block rounded-full px-4 py-2 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
-                        isActive
-                          ? "bg-primary/10 text-primary"
-                          : "text-text-muted hover:bg-white/60 hover:text-text"
-                      }`}
+          <>
+            <motion.div
+              key="mobile-nav-backdrop"
+              className="fixed inset-0 z-40 bg-white/80 backdrop-blur-sm"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={closeMenu}
+              aria-hidden
+            />
+            <motion.div
+              key="mobile-nav"
+              id="mobile-nav"
+              className="absolute left-0 right-0 top-[calc(100%+0.75rem)] z-50 overflow-hidden rounded-3xl border border-white/50 bg-white/60 p-4 shadow-2xl backdrop-blur-xl backdrop-saturate-150"
+              variants={menuVariants}
+              initial="hidden"
+              animate="visible"
+              exit="exit"
+              style={{ transformOrigin: "top center" }}
+            >
+              <nav className="flex flex-col gap-1 text-base font-medium text-text">
+                {mainNav.map((item, index) => {
+                  const isActive =
+                    item.href === "/"
+                      ? pathname === "/"
+                      : pathname === item.href || pathname.startsWith(`${item.href}/`);
+                  return (
+                    <motion.div
+                      key={item.href}
+                      initial={{ opacity: 0, y: -6 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -6 }}
+                      transition={{ duration: 0.22, delay: 0.08 + index * 0.04, ease: "easeOut" }}
                     >
-                      {item.label}
-                    </Link>
-                  </motion.div>
-                );
-              })}
-            </nav>
-          </motion.div>
+                      <Link
+                        href={item.href}
+                        onClick={closeMenu}
+                        aria-current={isActive ? "page" : undefined}
+                        className={`block rounded-full px-4 py-2 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
+                          isActive
+                            ? "bg-primary/10 text-primary"
+                            : "text-text-muted hover:bg-white/60 hover:text-text"
+                        }`}
+                      >
+                        {item.label}
+                      </Link>
+                    </motion.div>
+                  );
+                })}
+              </nav>
+            </motion.div>
+          </>
         ) : null}
       </AnimatePresence>
     </div>


### PR DESCRIPTION
## Summary
- add a fixed, blurred backdrop behind the mobile navigation menu so page content no longer shows through
- ensure the toggle button stays above the overlay by adjusting stacking order and container positioning

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2ef493608832fa7c7194058fc7010