### PR TITLE
Update WhatsApp CTA icon

### DIFF
--- a/tk-kartikasari/components/CTAButton.tsx
+++ b/tk-kartikasari/components/CTAButton.tsx
@@ -46,29 +46,16 @@ export default function CTAButton({
   return (
     <a href={waLink(finalMessage)} className={classes}>
       <span className="flex items-center gap-3">
-        <span className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/50 bg-white/20 text-white backdrop-blur-sm backdrop-saturate-150 transition group-hover:bg-white/30">
+        <span className="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/50 bg-white text-[#25D366] transition group-hover:bg-white/90">
           <svg
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 16 16"
+            aria-hidden="true"
+            focusable="false"
             className="h-5 w-5"
           >
             <path
-              d="M19.5 12c0 4.142-3.582 7.5-8 7.5-.996 0-1.953-.153-2.846-.437L4.5 20.25l1.38-3.611C5.3 15.487 4.75 13.815 4.75 12c0-4.142 3.582-7.5 8-7.5s6.75 3.358 6.75 7.5Z"
-              stroke="currentColor"
-              strokeWidth="1.6"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              opacity="0.85"
-            />
-            <path
-              d="M9.5 10.6c.25-.8.8-1 1.3-.8 1.5.6 1.6 2 1.6 2s1.2.2 1.6 1c.3.6-.3 1.3-1 1.9"
-              stroke="currentColor"
-              strokeWidth="1.6"
-              strokeLinecap="round"
-              strokeLinejoin="round"
+              fill="currentColor"
+              d="M13.601 2.326A7.85 7.85 0 0 0 7.994 0C3.627 0 .068 3.558.064 7.926c0 1.399.366 2.76 1.057 3.965L0 16l4.204-1.102a7.9 7.9 0 0 0 3.79.965h.004c4.368 0 7.926-3.558 7.93-7.93A7.9 7.9 0 0 0 13.6 2.326Zm-5.607 12.195a6.6 6.6 0 0 1-3.356-.92l-.24-.144-2.494.654.666-2.433-.156-.251a6.56 6.56 0 0 1-1.007-3.505c0-3.626 2.957-6.584 6.591-6.584a6.56 6.56 0 0 1 4.66 1.931 6.56 6.56 0 0 1 1.928 4.66c-.004 3.639-2.961 6.592-6.592 6.592Zm3.615-4.934c-.197-.099-1.17-.578-1.353-.646-.182-.065-.315-.099-.445.099-.133.197-.513.646-.627.775-.114.133-.232.148-.43.05-.197-.1-.836-.308-1.592-.985-.59-.525-.985-1.175-1.103-1.372-.114-.198-.011-.304.088-.403.087-.088.197-.232.296-.346.1-.114.133-.198.198-.33.065-.134.034-.248-.015-.347-.05-.099-.445-1.076-.612-1.47-.16-.389-.323-.335-.445-.34-.114-.007-.247-.007-.38-.007a.73.73 0 0 0-.529.247c-.182.198-.691.677-.691 1.654s.71 1.916.81 2.049c.098.133 1.394 2.132 3.383 2.992.47.205.84.326 1.129.418.475.152.904.129 1.246.08.38-.058 1.171-.48 1.338-.943.164-.464.164-.86.114-.943-.049-.084-.182-.133-.38-.232"
             />
           </svg>
         </span>


### PR DESCRIPTION
## Summary
- replace the improvised WhatsApp graphic in the CTA button with an accurate SVG glyph
- restyle the icon container to highlight the brand green while keeping the button layout intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2efad96dc832f98734cbe681c6933