### PR TITLE
Use Next.js Image for blog thumbnails

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,5 +1,6 @@
 
 import { notFound } from 'next/navigation';
+import Image from 'next/image';
 import { blogPosts, BlogPost } from '@/content/blog';
 import PageHeader from '@/components/layout/PageHeader';
 import { Calendar, Person, Tag, Clock } from 'react-bootstrap-icons'; // Added Clock icon
@@ -73,8 +74,15 @@ export default async function BlogPostPage({ params }: PageProps) {
             </div>
           </div>
 
-          <div className="aspect-[16/9] my-8 w-full overflow-hidden rounded-2xl">
-            <img src={post.image} alt={post.title} className="h-full w-full object-cover" />
+          <div className="relative aspect-[16/9] my-8 w-full overflow-hidden rounded-2xl">
+            <Image
+              src={post.image}
+              alt={post.title}
+              fill
+              className="object-cover"
+              sizes="(min-width: 1024px) 800px, 100vw"
+              priority
+            />
           </div>
 
           <div

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,5 +1,6 @@
 
 import Link from 'next/link';
+import Image from 'next/image';
 import PageHeader from '@/components/layout/PageHeader';
 import { blogPosts, BlogPost } from '@/content/blog';
 import { ArrowRight } from 'react-bootstrap-icons';
@@ -30,8 +31,15 @@ function BlogCard({ post }: { post: BlogPost }) {
   return (
     <Link href={`/blog/${post.slug}`}>
       <div className="card h-full transform-gpu bg-white/60 shadow-soft backdrop-blur-xl transition-all duration-300 hover:-translate-y-1 hover:shadow-primary/20">
-        <div className="aspect-[16/9] w-full overflow-hidden rounded-t-2xl">
-          <img src={post.image} alt={post.title} className="h-full w-full object-cover" />
+        <div className="relative aspect-[16/9] w-full overflow-hidden rounded-t-2xl">
+          <Image
+            src={post.image}
+            alt={post.title}
+            fill
+            className="object-cover"
+            sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+            loading="lazy"
+          />
         </div>
         <div className="flex h-full flex-col p-6">
           <p className="text-sm text-text-muted">

--- a/components/home/HomePageContent.tsx
+++ b/components/home/HomePageContent.tsx
@@ -18,6 +18,7 @@ import type {
 import { BlogPost } from "@/content/blog";
 import { ArrowRight, CheckCircle } from "react-bootstrap-icons";
 import Link from "next/link";
+import Image from "next/image";
 import AnimateIn from "@/components/AnimateIn";
 
 type HomePageContentProps = {
@@ -403,8 +404,15 @@ export default function HomePageContent({
               {blogPosts.slice(0, 3).map((post) => (
                 <Link href={`/blog/${post.slug}`} key={post.slug} className="focus-visible-ring group block rounded-2xl">
                   <article className="card h-full transform-gpu bg-white/60 shadow-soft backdrop-blur-xl transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-primary/20">
-                    <div className="aspect-[16/9] w-full overflow-hidden rounded-t-2xl">
-                      <img src={post.image} alt={post.title} className="h-full w-full object-cover" />
+                    <div className="relative aspect-[16/9] w-full overflow-hidden rounded-t-2xl">
+                      <Image
+                        src={post.image}
+                        alt={post.title}
+                        fill
+                        className="object-cover"
+                        sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+                        loading="lazy"
+                      />
                     </div>
                     <div className="flex h-full flex-col p-6">
                       <p className="text-sm text-text-muted">


### PR DESCRIPTION
## Summary
- replace blog teaser thumbnails on the home page with Next.js `<Image>` including responsive sizing and lazy loading
- update the blog listing grid to use `<Image>` for consistent aspect ratios and optimized loading
- render the blog post hero media with `<Image>` and explicit sizing for better LCP handling

## Testing
- npm run lint *(fails: Unable to resolve path to module '@fontsource-variable/inter'; existing warning about remaining <img> usage)*

------
https://chatgpt.com/codex/tasks/task_e_68d6805887a0832f8d80df8d94735821