### PR TITLE
feat: lazily load contact page map

### DIFF
--- a/components/MapEmbed.tsx
+++ b/components/MapEmbed.tsx
@@ -1,15 +1,15 @@
-import site from '@/data/site.json'
+import MapEmbedClient from "./MapEmbedClient"
+import site from "@/data/site.json"
+
+const MAP_PREVIEW_IMAGE = {
+  src: "/images/map-placeholder.svg",
+  alt: "Pratinjau lokasi TK Kartikasari dalam peta",
+} as const
+
 export default function MapEmbed() {
   return (
     <div className="card overflow-hidden">
-      <iframe
-        src={site.mapsUrl}
-        className="w-full h-[320px]"
-        loading="lazy"
-        referrerPolicy="no-referrer-when-downgrade"
-        title="Lokasi TK Kartikasari"
-        aria-label="Lokasi TK Kartikasari"
-      />
+      <MapEmbedClient mapSrc={site.mapsUrl} previewImage={MAP_PREVIEW_IMAGE} />
     </div>
   )
 }

--- a/components/MapEmbedClient.tsx
+++ b/components/MapEmbedClient.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+import Image from "next/image"
+import { useEffect, useRef, useState } from "react"
+
+type MapEmbedClientProps = {
+  mapSrc: string
+  previewImage: {
+    src: string
+    alt: string
+  }
+}
+
+const PLACEHOLDER_DESCRIPTION =
+  "Pratinjau peta TK Kartikasari. Klik tombol di bawah untuk membuka peta interaktif dari Google Maps."
+
+export default function MapEmbedClient({ mapSrc, previewImage }: MapEmbedClientProps) {
+  const [hasUserActivated, setHasUserActivated] = useState(false)
+  const [hasViewportTrigger, setHasViewportTrigger] = useState(false)
+  const [shouldRenderIframe, setShouldRenderIframe] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const intersectionObserver = useRef<IntersectionObserver | null>(null)
+  const activationTimeout = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (shouldRenderIframe) {
+      return
+    }
+
+    if (typeof window === "undefined" || !containerRef.current) {
+      return
+    }
+
+    intersectionObserver.current = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            if (activationTimeout.current === null) {
+              activationTimeout.current = window.setTimeout(() => {
+                setHasViewportTrigger(true)
+              }, 400)
+            }
+          } else if (activationTimeout.current !== null) {
+            window.clearTimeout(activationTimeout.current)
+            activationTimeout.current = null
+          }
+        })
+      },
+      {
+        rootMargin: "160px 0px",
+        threshold: 0.25,
+      }
+    )
+
+    intersectionObserver.current.observe(containerRef.current)
+
+    return () => {
+      intersectionObserver.current?.disconnect()
+      if (activationTimeout.current !== null) {
+        window.clearTimeout(activationTimeout.current)
+      }
+    }
+  }, [shouldRenderIframe])
+
+  useEffect(() => {
+    if (hasUserActivated || hasViewportTrigger) {
+      setShouldRenderIframe(true)
+    }
+  }, [hasUserActivated, hasViewportTrigger])
+
+  const handleActivate = () => {
+    setHasUserActivated(true)
+  }
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      {shouldRenderIframe ? (
+        <iframe
+          src={mapSrc}
+          className="w-full h-[320px] border-0"
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+          title="Lokasi TK Kartikasari"
+          aria-label="Lokasi TK Kartikasari"
+        />
+      ) : (
+        <div className="relative h-[320px] w-full">
+          <Image
+            src={previewImage.src}
+            alt={previewImage.alt}
+            fill
+            priority={false}
+            sizes="(min-width: 768px) 720px, 100vw"
+            className="object-cover"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-black/40" aria-hidden="true" />
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 px-6 text-center text-white">
+            <p className="text-sm md:text-base" aria-live="polite">
+              {PLACEHOLDER_DESCRIPTION}
+            </p>
+            <button
+              type="button"
+              onClick={handleActivate}
+              className="btn btn-primary"
+              aria-label="Aktifkan peta interaktif"
+            >
+              Lihat peta interaktif
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/public/images/map-placeholder.svg
+++ b/public/images/map-placeholder.svg
@@ -1,0 +1,29 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0F172A" />
+      <stop offset="50%" stop-color="#1D4ED8" />
+      <stop offset="100%" stop-color="#0EA5E9" />
+    </linearGradient>
+    <pattern id="grid" patternUnits="userSpaceOnUse" width="80" height="80" patternTransform="scale(1)">
+      <path d="M 80 0 L 0 0 0 80" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="2" />
+    </pattern>
+    <filter id="shadow" x="-50%" y="-50%" width="200%" height="200%">
+      <feDropShadow dx="0" dy="8" stdDeviation="16" flood-color="rgba(15, 23, 42, 0.45)" />
+    </filter>
+  </defs>
+  <rect width="1600" height="900" fill="url(#gradient)" />
+  <rect width="1600" height="900" fill="url(#grid)" />
+  <g filter="url(#shadow)">
+    <circle cx="800" cy="420" r="180" fill="#F59E0B" />
+    <circle cx="800" cy="420" r="120" fill="#FEF3C7" />
+    <path d="M800 210C708 210 633 284 633 375C633 465 709 592 800 720C891 592 967 465 967 375C967 284 892 210 800 210Z" fill="#DC2626" />
+    <circle cx="800" cy="375" r="70" fill="#FDE68A" stroke="#7C2D12" stroke-width="16" />
+  </g>
+  <text x="800" y="790" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="72" font-weight="600" fill="rgba(255,255,255,0.9)">
+    TK Kartikasari
+  </text>
+  <text x="800" y="850" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="32" fill="rgba(255,255,255,0.75)">
+    Lihat lokasi di Google Maps
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- replace the server MapEmbed with a preview card that defers third-party embeds
- add a client wrapper that only mounts the Google Maps iframe after interaction or viewport visibility
- add an SVG preview asset to preserve layout and deliver an optimized placeholder

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6807272dc832fb72240691ba88dd8