### PR TITLE
Add Firebase auth initialization to Firebase helper

### DIFF
--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,6 +1,7 @@
 
 import { initializeApp, getApps, getApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
+import { getAuth } from "firebase/auth";
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -14,5 +15,6 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 const db = getFirestore(app);
+const auth = getAuth(app);
 
-export { app, db };
+export { app, db, auth };


### PR DESCRIPTION
## Summary
- import the Firebase auth SDK alongside app and firestore helpers
- initialize an auth instance tied to the shared Firebase app
- export the auth instance so callers can reuse it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7645f8c9c832f863620e31c3f33dc