### PR TITLE
Add admin blog dashboard with engagement features

### DIFF
--- a/app/admin/blog/page.tsx
+++ b/app/admin/blog/page.tsx
@@ -1,0 +1,440 @@
+'use client';
+
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { addDoc, collection, deleteDoc, doc, onSnapshot, orderBy, query, serverTimestamp } from 'firebase/firestore';
+import { getDownloadURL, ref, uploadBytes } from 'firebase/storage';
+import { db, storage } from '@/lib/firebase';
+import { slugify } from '@/utils/slugify';
+
+interface BlogPost {
+  id: string;
+  title: string;
+  slug: string;
+  date: string;
+  body: string;
+  coverImage?: string;
+}
+
+interface FormState {
+  title: string;
+  slug: string;
+  date: string;
+  body: string;
+  coverImageFile: File | null;
+}
+
+const getInitialFormState = (): FormState => ({
+  title: '',
+  slug: '',
+  date: new Date().toISOString().split('T')[0],
+  body: '',
+  coverImageFile: null,
+});
+
+export default function BlogManagementPage() {
+  const [posts, setPosts] = useState<BlogPost[]>([]);
+  const [form, setForm] = useState<FormState>(() => getInitialFormState());
+  const [coverPreview, setCoverPreview] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [messageType, setMessageType] = useState<'success' | 'error' | 'info' | null>(null);
+  const bodyImageInputRef = useRef<HTMLInputElement | null>(null);
+  const titleFieldId = useId();
+  const slugFieldId = useId();
+  const dateFieldId = useId();
+  const coverFieldId = useId();
+  const bodyFieldId = useId();
+
+  useEffect(() => {
+    const q = query(collection(db, 'blogs'), orderBy('date', 'desc'));
+    const unsubscribe = onSnapshot(q, (snapshot) => {
+      const fetchedPosts: BlogPost[] = snapshot.docs.map((docSnapshot) => {
+        const data = docSnapshot.data();
+        return {
+          id: docSnapshot.id,
+          title: data.title,
+          slug: data.slug,
+          date: data.date,
+          body: data.body,
+          coverImage: data.coverImage,
+        };
+      });
+      setPosts(fetchedPosts);
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  const resetForm = useCallback(() => {
+    setForm(getInitialFormState());
+    setCoverPreview(null);
+  }, []);
+
+  useEffect(() => {
+    if (!form.coverImageFile) {
+      setCoverPreview(null);
+      return;
+    }
+
+    const url = URL.createObjectURL(form.coverImageFile);
+    setCoverPreview(url);
+
+    return () => URL.revokeObjectURL(url);
+  }, [form.coverImageFile]);
+
+  useEffect(() => {
+    if (!message || messageType === 'error') {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      setMessage(null);
+      setMessageType(null);
+    }, 6000);
+
+    return () => clearTimeout(timeout);
+  }, [message, messageType]);
+
+  const handleTitleChange = useCallback((value: string) => {
+    setForm((prev) => ({
+      ...prev,
+      title: value,
+      slug: prev.slug || slugify(value),
+    }));
+  }, []);
+
+  const uploadFile = useCallback(
+    async (file: File, path: string) => {
+      const storageRef = ref(storage, path);
+      const snapshot = await uploadBytes(storageRef, file);
+      const downloadUrl = await getDownloadURL(snapshot.ref);
+      return downloadUrl;
+    },
+    []
+  );
+
+  const handleBodyImageUpload = useCallback(() => {
+    if (!bodyImageInputRef.current) {
+      return;
+    }
+    bodyImageInputRef.current.click();
+  }, []);
+
+  const handleBodyImageChange = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+
+      try {
+        setMessage('Mengunggah gambar konten...');
+        setMessageType('info');
+        const path = `blog-content-images/${Date.now()}-${file.name}`;
+        const imageUrl = await uploadFile(file, path);
+        setForm((prev) => ({
+          ...prev,
+          body: `${prev.body}\n\n![Deskripsi gambar](${imageUrl})\n\n`,
+        }));
+        setMessage('Gambar berhasil ditambahkan ke konten.');
+        setMessageType('success');
+      } catch (error) {
+        console.error(error);
+        setMessage('Gagal mengunggah gambar konten.');
+        setMessageType('error');
+      } finally {
+        event.target.value = '';
+      }
+    },
+    [uploadFile]
+  );
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setIsSubmitting(true);
+      setMessage(null);
+      setMessageType(null);
+
+      try {
+        if (!form.title || !form.slug || !form.date || !form.body) {
+          throw new Error('Harap lengkapi seluruh field yang wajib diisi.');
+        }
+
+        const normalizedSlug = slugify(form.slug);
+        const slugAlreadyExists = posts.some((post) => post.slug === normalizedSlug);
+        if (slugAlreadyExists) {
+          throw new Error('Slug sudah digunakan. Gunakan slug lain agar URL unik.');
+        }
+
+        let coverUrl = '';
+
+        if (form.coverImageFile) {
+          if (!form.slug) {
+            throw new Error('Slug belum valid untuk membuat jalur gambar.');
+          }
+          const path = `blog-covers/${normalizedSlug}-${Date.now()}`;
+          coverUrl = await uploadFile(form.coverImageFile, path);
+        }
+
+        const postsCollection = collection(db, 'blogs');
+        await addDoc(postsCollection, {
+          title: form.title,
+          slug: normalizedSlug,
+          date: form.date,
+          body: form.body,
+          coverImage: coverUrl,
+          createdAt: serverTimestamp(),
+        });
+
+        resetForm();
+        setMessage('Postingan berhasil disimpan.');
+        setMessageType('success');
+      } catch (error: any) {
+        console.error(error);
+        setMessage(error.message || 'Terjadi kesalahan saat menyimpan data.');
+        setMessageType('error');
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [form, uploadFile, resetForm, posts]
+  );
+
+  const handleDelete = useCallback(async (postId: string) => {
+    const confirmation = confirm('Apakah Anda yakin ingin menghapus postingan ini?');
+    if (!confirmation) return;
+
+    try {
+      await deleteDoc(doc(db, 'blogs', postId));
+      setMessage('Postingan berhasil dihapus.');
+      setMessageType('success');
+    } catch (error) {
+      console.error(error);
+      setMessage('Gagal menghapus postingan.');
+      setMessageType('error');
+    }
+  }, []);
+
+  return (
+    <main className="container mx-auto py-8">
+      <h1 className="mb-8 text-3xl font-bold">Kelola Blog & Kegiatan</h1>
+
+      {message && (
+        <div
+          className={`mb-6 rounded-md border p-4 text-sm ${
+            messageType === 'error'
+              ? 'border-red-200 bg-red-50 text-red-700'
+              : messageType === 'success'
+                ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                : 'border-primary/20 bg-primary/5 text-primary'
+          }`}
+        >
+          {message}
+        </div>
+      )}
+
+      <section className="mb-12">
+        <h2 className="mb-4 text-2xl font-semibold">Tambah Postingan Baru</h2>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div>
+            <label className="mb-2 block text-sm font-medium text-gray-700" htmlFor={titleFieldId}>
+              Judul*
+            </label>
+            <input
+              type="text"
+              id={titleFieldId}
+              value={form.title}
+              onChange={(event) => handleTitleChange(event.target.value)}
+              placeholder="Misal: Kegiatan Karnaval Sekolah"
+              className="w-full rounded-md border border-gray-300 p-3 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              required
+            />
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm font-medium text-gray-700" htmlFor={slugFieldId}>
+              Slug URL*
+            </label>
+            <input
+              type="text"
+              id={slugFieldId}
+              value={form.slug}
+              onChange={(event) =>
+                setForm((prev) => ({
+                  ...prev,
+                  slug: slugify(event.target.value),
+                }))
+              }
+              placeholder="kegiatan-karnaval-sekolah"
+              className="w-full rounded-md border border-gray-300 p-3 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              required
+            />
+            <p className="mt-2 text-sm text-gray-500">Slug digunakan sebagai bagian dari URL. Hanya huruf kecil, angka, dan tanda hubung.</p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <div>
+              <label className="mb-2 block text-sm font-medium text-gray-700" htmlFor={dateFieldId}>
+                Tanggal Publikasi*
+              </label>
+              <input
+                type="date"
+                id={dateFieldId}
+                value={form.date}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    date: event.target.value,
+                  }))
+                }
+                className="w-full rounded-md border border-gray-300 p-3 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                required
+              />
+            </div>
+
+            <div>
+              <label className="mb-2 block text-sm font-medium text-gray-700" htmlFor={coverFieldId}>
+                Gambar Cover
+              </label>
+              <input
+                type="file"
+                accept="image/*"
+                id={coverFieldId}
+                onChange={(event) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    coverImageFile: event.target.files?.[0] ?? null,
+                  }))
+                }
+                className="w-full rounded-md border border-gray-300 p-3 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              />
+              {coverPreview && (
+                <div className="mt-4">
+                  <p className="mb-2 text-sm text-gray-600">Pratinjau cover:</p>
+                  <div className="relative h-48 w-full overflow-hidden rounded-md">
+                    <Image src={coverPreview} alt="Pratinjau cover" fill className="object-cover" unoptimized />
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <div className="mb-2 flex items-center justify-between">
+              <label className="text-sm font-medium text-gray-700" htmlFor={bodyFieldId}>
+                Konten Utama*
+              </label>
+              <button
+                type="button"
+                onClick={handleBodyImageUpload}
+                className="rounded-md border border-primary px-3 py-1 text-sm font-medium text-primary transition hover:bg-primary hover:text-white"
+              >
+                + Tambah Gambar ke Konten
+              </button>
+            </div>
+            <textarea
+              value={form.body}
+              id={bodyFieldId}
+              onChange={(event) =>
+                setForm((prev) => ({
+                  ...prev,
+                  body: event.target.value,
+                }))
+              }
+              placeholder={
+                'Tulis cerita kegiatan di sini dalam format Markdown.\n\nContoh menambahkan gambar: ![Deskripsi](https://url-gambar.com)'
+              }
+              className="min-h-[240px] w-full rounded-md border border-gray-300 p-3 font-mono text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              required
+            />
+            <input
+              ref={bodyImageInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={handleBodyImageChange}
+            />
+            <p className="mt-2 text-sm text-gray-500">Konten menggunakan format Markdown. Anda dapat menambahkan heading, daftar, dan lainnya.</p>
+          </div>
+
+          <div className="flex items-center justify-end gap-3">
+            <button
+              type="button"
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100"
+              disabled={isSubmitting}
+              onClick={() => {
+                resetForm();
+                setMessage(null);
+                setMessageType(null);
+              }}
+            >
+              Reset
+            </button>
+            <button
+              type="submit"
+              className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? 'Menyimpan...' : 'Simpan Postingan'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold">Daftar Postingan</h2>
+        {posts.length === 0 ? (
+          <p className="text-sm text-gray-500">Belum ada data postingan. Silakan tambah postingan baru.</p>
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-left text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 font-semibold text-gray-600">Judul</th>
+                  <th className="px-4 py-3 font-semibold text-gray-600">Tanggal</th>
+                  <th className="px-4 py-3 font-semibold text-gray-600">Slug</th>
+                  <th className="px-4 py-3 text-right font-semibold text-gray-600">Aksi</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {posts.map((post) => (
+                  <tr key={post.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 font-medium text-gray-800">{post.title}</td>
+                    <td className="px-4 py-3 text-gray-600">
+                      {new Date(post.date).toLocaleDateString('id-ID', {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                      })}
+                    </td>
+                    <td className="px-4 py-3 text-gray-500">{post.slug}</td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex items-center justify-end gap-2">
+                        <Link
+                          href={`/blog/${post.slug}`}
+                          className="rounded-md border border-primary px-3 py-1 text-sm font-medium text-primary transition hover:bg-primary hover:text-white"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Lihat
+                        </Link>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(post.id)}
+                          className="rounded-md border border-red-200 px-3 py-1 text-sm font-medium text-red-600 transition hover:bg-red-50"
+                        >
+                          Hapus
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -9,7 +9,13 @@ export default function AdminPage() {
         <Link href="/admin/content">
           <div className="block rounded-lg border border-gray-200 bg-white p-6 shadow-md transition-shadow duration-300 hover:shadow-lg">
             <h2 className="mb-2 text-2xl font-semibold">Content Management</h2>
-            <p className="text-gray-600">Edit the text content of your website's pages.</p>
+            <p className="text-gray-600">Edit the text content of your website&apos;s pages.</p>
+          </div>
+        </Link>
+        <Link href="/admin/blog">
+          <div className="block rounded-lg border border-gray-200 bg-white p-6 shadow-md transition-shadow duration-300 hover:shadow-lg">
+            <h2 className="mb-2 text-2xl font-semibold">Blog &amp; Kegiatan</h2>
+            <p className="text-gray-600">Buat postingan baru, unggah gambar, dan kelola berita terbaru.</p>
           </div>
         </Link>
         {/* Other admin sections can be added here in the future */}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,9 +1,10 @@
 
 import { notFound } from 'next/navigation';
 import Image from 'next/image';
-import { getPosts, getPostBySlug, Post } from '@/lib/blog'; // Import Post from @/lib/blog
+import { getPosts, getPostBySlug } from '@/lib/blog'; // Import Post from @/lib/blog
 import { Calendar, Person } from 'react-bootstrap-icons';
 import Mdx from '@/components/mdx/Mdx';
+import EngagementSection from '@/components/blog/EngagementSection';
 
 // Generate static paths for all blog posts
 export async function generateStaticParams() {
@@ -65,6 +66,9 @@ export default async function BlogPostPage({ params }: PageProps) {
           <div className="prose prose-lg mt-8 max-w-none prose-h2:text-2xl prose-h2:font-semibold prose-h2:text-text prose-p:text-text-muted prose-a:text-primary hover:prose-a:text-primary/80">
             <Mdx code={post.body.raw} />
           </div>
+        </div>
+        <div className="mx-auto mt-8 max-w-4xl">
+          <EngagementSection slug={post.slug} />
         </div>
       </div>
     </article>

--- a/components/blog/EngagementSection.tsx
+++ b/components/blog/EngagementSection.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useEffect, useMemo, useState, useId } from 'react';
+import { Timestamp, addDoc, collection, doc, increment, onSnapshot, query, serverTimestamp, setDoc, where } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+
+interface Comment {
+  id: string;
+  name: string;
+  message: string;
+  createdAt?: Timestamp | null;
+}
+
+interface EngagementSectionProps {
+  slug: string;
+}
+
+function formatDate(timestamp?: Timestamp | null) {
+  if (!timestamp) return '';
+  const date = timestamp.toDate();
+  return date.toLocaleString('id-ID', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export default function EngagementSection({ slug }: EngagementSectionProps) {
+  const [likeCount, setLikeCount] = useState<number>(0);
+  const [liked, setLiked] = useState<boolean>(false);
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [name, setName] = useState('');
+  const [message, setMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const nameFieldId = useId();
+  const messageFieldId = useId();
+
+  const likeDocRef = useMemo(() => doc(db, 'blogLikes', slug), [slug]);
+  const commentsQuery = useMemo(() => query(collection(db, 'blogComments'), where('slug', '==', slug)), [slug]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const storedPreference = localStorage.getItem(`blog-liked-${slug}`);
+    setLiked(storedPreference === 'true');
+  }, [slug]);
+
+  useEffect(() => {
+    if (!feedback) return;
+    const timeout = setTimeout(() => setFeedback(null), 5000);
+    return () => clearTimeout(timeout);
+  }, [feedback]);
+
+  useEffect(() => {
+    const unsubscribeLikes = onSnapshot(likeDocRef, (snapshot) => {
+      setLikeCount((snapshot.data()?.count as number) || 0);
+    });
+
+    return () => unsubscribeLikes();
+  }, [likeDocRef]);
+
+  useEffect(() => {
+    const unsubscribeComments = onSnapshot(commentsQuery, (snapshot) => {
+      const commentList = snapshot.docs
+        .map((docSnapshot) => {
+          const data = docSnapshot.data() as Omit<Comment, 'id'>;
+          return {
+            id: docSnapshot.id,
+            name: data.name,
+            message: data.message,
+            createdAt: data.createdAt ?? null,
+          };
+        })
+        .sort((a, b) => {
+          const aTime = a.createdAt ? a.createdAt.toMillis() : 0;
+          const bTime = b.createdAt ? b.createdAt.toMillis() : 0;
+          return bTime - aTime;
+        });
+
+      setComments(commentList);
+    });
+
+    return () => unsubscribeComments();
+  }, [commentsQuery]);
+
+  const toggleLike = async () => {
+    try {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      if (liked) {
+        if (likeCount > 0) {
+          await setDoc(likeDocRef, { count: increment(-1) }, { merge: true });
+        }
+        localStorage.removeItem(`blog-liked-${slug}`);
+        setLiked(false);
+        setLikeCount((prev) => (prev > 0 ? prev - 1 : 0));
+      } else {
+        await setDoc(likeDocRef, { count: increment(1) }, { merge: true });
+        localStorage.setItem(`blog-liked-${slug}`, 'true');
+        setLiked(true);
+        setLikeCount((prev) => prev + 1);
+      }
+    } catch (error) {
+      console.error(error);
+      setFeedback('Terjadi kesalahan saat memperbarui suka.');
+    }
+  };
+
+  const handleSubmitComment = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setFeedback(null);
+
+    try {
+      const trimmedName = name.trim();
+      const trimmedMessage = message.trim();
+
+      if (!trimmedName || !trimmedMessage) {
+        throw new Error('Nama dan komentar wajib diisi.');
+      }
+
+      await addDoc(collection(db, 'blogComments'), {
+        slug,
+        name: trimmedName,
+        message: trimmedMessage,
+        createdAt: serverTimestamp(),
+      });
+
+      setName('');
+      setMessage('');
+      setFeedback('Komentar berhasil dikirim.');
+    } catch (error: any) {
+      console.error(error);
+      setFeedback(error.message || 'Gagal mengirim komentar.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="mt-12 rounded-2xl border border-primary/10 bg-primary/5 p-6 shadow-sm">
+      <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-primary">Bagikan Apresiasi Anda</h2>
+          <p className="text-sm text-text-muted">Berikan tanda suka atau tinggalkan komentar tentang kegiatan ini.</p>
+        </div>
+        <button
+          onClick={toggleLike}
+          className={`flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold transition ${
+            liked
+              ? 'border-primary bg-primary text-white hover:bg-primary/90'
+              : 'border-primary text-primary hover:bg-primary/10'
+          }`}
+          type="button"
+        >
+          <span>{liked ? 'Terima kasih!' : 'Suka'}</span>
+          <span className="inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded-full bg-white px-2 text-primary shadow">
+            {likeCount}
+          </span>
+        </button>
+      </div>
+
+      {feedback && <p className="mt-4 text-sm text-primary">{feedback}</p>}
+
+      <div className="mt-8 grid gap-8 lg:grid-cols-[1.2fr_1fr]">
+        <div>
+          <h3 className="mb-4 text-lg font-semibold text-text">Komentar Wali Murid</h3>
+          {comments.length === 0 ? (
+            <p className="text-sm text-text-muted">Belum ada komentar. Jadilah yang pertama memberikan dukungan!</p>
+          ) : (
+            <ul className="space-y-4">
+              {comments.map((comment) => (
+                <li key={comment.id} className="rounded-xl bg-white/70 p-4 shadow-sm">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-semibold text-text">{comment.name}</span>
+                    <span className="text-xs text-text-muted">{formatDate(comment.createdAt)}</span>
+                  </div>
+                  <p className="mt-2 text-sm text-text-muted">{comment.message}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="rounded-xl bg-white p-4 shadow-sm">
+          <h3 className="mb-3 text-lg font-semibold text-text">Tinggalkan Komentar</h3>
+          <form onSubmit={handleSubmitComment} className="space-y-4">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-text" htmlFor={nameFieldId}>
+                Nama*
+              </label>
+              <input
+                type="text"
+                id={nameFieldId}
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Nama Anda"
+                className="w-full rounded-md border border-gray-300 p-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                required
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium text-text" htmlFor={messageFieldId}>
+                Komentar*
+              </label>
+              <textarea
+                value={message}
+                id={messageFieldId}
+                onChange={(event) => setMessage(event.target.value)}
+                placeholder="Bagikan pengalaman atau dukungan Anda"
+                className="min-h-[120px] w-full rounded-md border border-gray-300 p-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                required
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/50"
+            >
+              {submitting ? 'Mengirim...' : 'Kirim Komentar'}
+            </button>
+          </form>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/home/HomePageContent.tsx
+++ b/components/home/HomePageContent.tsx
@@ -16,7 +16,7 @@ import type {
   HomeStat,
   HomeTimelineMilestone,
 } from "@/app/types/home";
-import { BlogPost } from "@/content/blog";
+import type { Post as BlogPost } from "@/lib/blog";
 import { ArrowRight, CheckCircle } from "react-bootstrap-icons";
 import Link from "next/link";
 import Image from "next/image";

--- a/lib/firebase-admin.ts
+++ b/lib/firebase-admin.ts
@@ -1,11 +1,16 @@
 
-import * as admin from 'firebase-admin';
+import { getApps, initializeApp, cert } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore } from 'firebase-admin/firestore';
 
-// Check if the admin app is already initialized
-if (!admin.apps.length) {
+function initializeFirebaseAdmin() {
+  if (getApps().length) {
+    return getApps()[0];
+  }
+
   try {
-    admin.initializeApp({
-      credential: admin.credential.cert({
+    return initializeApp({
+      credential: cert({
         projectId: process.env.FIREBASE_PROJECT_ID,
         clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
         privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\n/g, '\n'),
@@ -14,10 +19,12 @@ if (!admin.apps.length) {
     });
   } catch (error) {
     console.error('Firebase admin initialization error', error);
+    throw error;
   }
 }
 
-const adminDb = admin.firestore();
-const adminAuth = admin.auth();
+const adminApp = initializeFirebaseAdmin();
+const adminDb = getFirestore(adminApp);
+const adminAuth = getAuth(adminApp);
 
 export { adminDb, adminAuth };

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -2,6 +2,7 @@
 import { initializeApp, getApps, getApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
+import { getStorage } from "firebase/storage";
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -16,5 +17,6 @@ const firebaseConfig = {
 const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 const db = getFirestore(app);
 const auth = getAuth(app);
+const storage = getStorage(app);
 
-export { app, db, auth };
+export { app, db, auth, storage };

--- a/utils/slugify.ts
+++ b/utils/slugify.ts
@@ -1,0 +1,8 @@
+export function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '');
+}


### PR DESCRIPTION
## Summary
- add a protected admin blog dashboard with markdown content tools, image uploads, and slug validation
- expose firebase storage utilities and slugify helper used by the new dashboard
- surface a like and comment section on blog posts backed by Firestore collections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7667876e0832fbcd6c909c77b867e