### PR TITLE
Handle Firebase config gracefully to fix build

### DIFF
--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -4,6 +4,10 @@ import { adminAuth } from '@/lib/firebase-admin';
 
 export async function POST(request: Request) {
   try {
+    if (!adminAuth) {
+      return NextResponse.json({ status: 'error', message: 'Firebase admin is not configured.' }, { status: 500 });
+    }
+
     const { idToken } = await request.json();
 
     // Set session expiration to 5 days.

--- a/app/api/auth/verify/route.ts
+++ b/app/api/auth/verify/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { adminAuth } from '@/lib/firebase-admin';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  if (!adminAuth) {
+    return NextResponse.json({ status: 'error', message: 'Firebase admin is not configured.' }, { status: 500 });
+  }
+
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('session')?.value;
+
+  if (!sessionCookie) {
+    return NextResponse.json({ status: 'error', message: 'Missing session cookie' }, { status: 401 });
+  }
+
+  try {
+    await adminAuth.verifySessionCookie(sessionCookie, true /** checkRevoked */);
+    return NextResponse.json({ status: 'success' });
+  } catch (error) {
+    console.error('Session verification error:', error);
+    return NextResponse.json({ status: 'error', message: 'Invalid session' }, { status: 401 });
+  }
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -15,11 +15,11 @@ export async function generateStaticParams() {
 }
 
 type PageProps = {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 };
 
 export default async function BlogPostPage({ params }: PageProps) {
-  const { slug } = params;
+  const { slug } = await params;
   const post = await getPostBySlug(slug);
 
   if (!post) {

--- a/app/disklaimer/page.tsx
+++ b/app/disklaimer/page.tsx
@@ -1,8 +1,9 @@
 
 import { Metadata } from 'next';
 import { doc, getDoc } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
+import { getFirestoreDb } from '@/lib/firebase';
 import siteData from '@/data/site.json';
+import { disklaimer as fallbackDisclaimer, kebijakanPrivasi as fallbackPrivacyPolicy, syaratDanKetentuan as fallbackTerms } from '@/content/legal';
 
 // Define a type for the legal data for better type-safety
 type LegalPageData = {
@@ -16,14 +17,30 @@ type LegalPageData = {
 };
 
 async function getLegalData(): Promise<LegalPageData> {
-    const docRef = doc(db, 'pages', 'legal');
-    const docSnap = await getDoc(docRef);
+    const fallbackData: LegalPageData = {
+        disclaimer: fallbackDisclaimer,
+        privacyPolicy: fallbackPrivacyPolicy,
+        termsAndConditions: fallbackTerms,
+    };
 
-    if (!docSnap.exists()) {
-        throw new Error("Legal page data not found in Firestore.");
+    const db = getFirestoreDb();
+    if (!db) {
+        return fallbackData;
     }
 
-    return docSnap.data() as LegalPageData;
+    try {
+        const docRef = doc(db, 'pages', 'legal');
+        const docSnap = await getDoc(docRef);
+
+        if (!docSnap.exists()) {
+            throw new Error("Legal page data not found in Firestore.");
+        }
+
+        return docSnap.data() as LegalPageData;
+    } catch (error) {
+        console.error('Failed to fetch legal page data from Firestore:', error);
+        return fallbackData;
+    }
 }
 
 // Generate metadata dynamically

--- a/app/kebijakan-privasi/page.tsx
+++ b/app/kebijakan-privasi/page.tsx
@@ -1,8 +1,9 @@
 
 import { Metadata } from 'next';
 import { doc, getDoc } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
+import { getFirestoreDb } from '@/lib/firebase';
 import siteData from '@/data/site.json';
+import { kebijakanPrivasi as fallbackPrivacyPolicy, disklaimer as fallbackDisclaimer, syaratDanKetentuan as fallbackTerms } from '@/content/legal';
 
 // Define a type for the legal data for better type-safety
 type LegalPageData = {
@@ -16,14 +17,30 @@ type LegalPageData = {
 };
 
 async function getLegalData(): Promise<LegalPageData> {
-    const docRef = doc(db, 'pages', 'legal');
-    const docSnap = await getDoc(docRef);
+    const fallbackData: LegalPageData = {
+        privacyPolicy: fallbackPrivacyPolicy,
+        disclaimer: fallbackDisclaimer,
+        termsAndConditions: fallbackTerms,
+    };
 
-    if (!docSnap.exists()) {
-        throw new Error("Legal page data not found in Firestore.");
+    const db = getFirestoreDb();
+    if (!db) {
+        return fallbackData;
     }
 
-    return docSnap.data() as LegalPageData;
+    try {
+        const docRef = doc(db, 'pages', 'legal');
+        const docSnap = await getDoc(docRef);
+
+        if (!docSnap.exists()) {
+            throw new Error("Legal page data not found in Firestore.");
+        }
+
+        return docSnap.data() as LegalPageData;
+    } catch (error) {
+        console.error('Failed to fetch legal page data from Firestore:', error);
+        return fallbackData;
+    }
 }
 
 // Generate metadata dynamically

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,7 +4,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { signInWithEmailAndPassword } from 'firebase/auth';
-import { auth } from '@/lib/firebase';
+import { getFirebaseAuth } from '@/lib/firebase';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -17,6 +17,11 @@ export default function LoginPage() {
     setError(null);
 
     try {
+      const auth = getFirebaseAuth();
+      if (!auth) {
+        throw new Error('Firebase Auth belum dikonfigurasi.');
+      }
+
       const userCredential = await signInWithEmailAndPassword(auth, email, password);
       const user = userCredential.user;
       const idToken = await user.getIdToken();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,23 @@
 
 import { doc, getDoc } from 'firebase/firestore';
-import { db } from '@/lib/firebase'; // Our new firebase config
+import { getFirestoreDb } from '@/lib/firebase';
 import HomePageContent from "@/components/home/HomePageContent";
 import JsonLd from "@/components/JsonLd";
 import { getPosts } from "@/lib/blog";
 import site from "@/data/site.json";
 import { createPageMetadata } from "@/lib/metadata";
 import { preschoolSchema } from "@/lib/schema";
-
-// Re-export the description for metadata
-const homeHeroDescription = "TK Kartikasari adalah taman kanak-kanak yang berfokus pada pengembangan anak usia dini melalui metode pembelajaran yang inovatif dan menyenangkan.";
+import {
+  homeHeroDescription,
+  homeStats,
+  homeHighlights,
+  homePrograms,
+  homeJourney,
+  homeFaqs,
+  homeCredentials,
+  homeCurriculumPillars,
+  homeTimeline,
+} from "@/content/home";
 
 export const metadata = createPageMetadata({
   title: "Beranda",
@@ -31,14 +39,44 @@ type HomePageData = {
 };
 
 async function getHomeData(): Promise<HomePageData> {
-    const docRef = doc(db, 'pages', 'home');
-    const docSnap = await getDoc(docRef);
-
-    if (!docSnap.exists()) {
-        throw new Error("Home page data not found in Firestore.");
+    const db = getFirestoreDb();
+    if (!db) {
+        return {
+            heroDescription: homeHeroDescription,
+            stats: homeStats,
+            highlights: homeHighlights,
+            programs: homePrograms,
+            journey: homeJourney,
+            faqs: homeFaqs,
+            credentials: homeCredentials,
+            curriculumPillars: homeCurriculumPillars,
+            timeline: homeTimeline,
+        };
     }
 
-    return docSnap.data() as HomePageData;
+    try {
+        const docRef = doc(db, 'pages', 'home');
+        const docSnap = await getDoc(docRef);
+
+        if (!docSnap.exists()) {
+            throw new Error("Home page data not found in Firestore.");
+        }
+
+        return docSnap.data() as HomePageData;
+    } catch (error) {
+        console.error('Failed to fetch home page data from Firestore:', error);
+        return {
+            heroDescription: homeHeroDescription,
+            stats: homeStats,
+            highlights: homeHighlights,
+            programs: homePrograms,
+            journey: homeJourney,
+            faqs: homeFaqs,
+            credentials: homeCredentials,
+            curriculumPillars: homeCurriculumPillars,
+            timeline: homeTimeline,
+        };
+    }
 }
 
 export default async function Page() {

--- a/components/home/HomePageContent.tsx
+++ b/components/home/HomePageContent.tsx
@@ -361,32 +361,52 @@ export default function HomePageContent({
               description="Ikuti artikel terbaru dari kami untuk mendapatkan wawasan seputar dunia pendidikan anak usia dini dan melihat keseruan kegiatan di TK Kartikasari."
             />
             <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-              {blogPosts.slice(0, 3).map((post) => (
-                <Link href={`/blog/${post.slug}`} key={post.slug} className="focus-visible-ring group block rounded-2xl">
-                  <article className="card h-full transform-gpu bg-white/60 shadow-soft backdrop-blur-xl transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-primary/20">
-                    <div className="relative aspect-[16/9] w-full overflow-hidden rounded-t-2xl">
-                      <Image
-                        src={post.image}
-                        alt={post.title}
-                        fill
-                        className="object-cover"
-                        sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
-                        loading="lazy"
-                      />
-                    </div>
-                    <div className="flex h-full flex-col p-6">
-                      <p className="text-sm text-text-muted">
-                        {new Date(post.publishedAt).toLocaleDateString('id-ID', { year: 'numeric', month: 'long', day: 'numeric' })}
-                      </p>
-                      <h3 className="mt-2 text-lg font-semibold text-text">{post.title}</h3>
-                      <p className="mt-2 flex-grow text-sm text-text-muted">{post.description}</p>
-                      <div className="mt-4 flex items-center text-sm font-semibold text-primary transition-transform group-hover:translate-x-1">
-                        Baca selengkapnya <ArrowRight className="ml-1 h-4 w-4" />
+              {blogPosts.slice(0, 3).map((post) => {
+                const coverImage = post.coverImage;
+                const publishedAt = post.date;
+                const rawBody = post.body?.raw ?? '';
+                const normalizedBody = rawBody.replace(/[#*_`>\-]/g, '').replace(/\[(.*?)\]\(.*?\)/g, '$1').replace(/\s+/g, ' ').trim();
+                const description = normalizedBody.length > 160 ? `${normalizedBody.slice(0, 157)}...` : normalizedBody;
+
+                return (
+                  <Link href={`/blog/${post.slug}`} key={post.slug} className="focus-visible-ring group block rounded-2xl">
+                    <article className="card h-full transform-gpu bg-white/60 shadow-soft backdrop-blur-xl transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-primary/20">
+                      <div className="relative aspect-[16/9] w-full overflow-hidden rounded-t-2xl">
+                        {coverImage ? (
+                          <Image
+                            src={coverImage}
+                            alt={post.title}
+                            fill
+                            className="object-cover"
+                            sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center bg-secondary/10 text-secondary">
+                            <span className="text-sm font-semibold">TK Kartikasari</span>
+                          </div>
+                        )}
                       </div>
-                    </div>
-                  </article>
-                </Link>
-              ))}
+                      <div className="flex h-full flex-col p-6">
+                        <p className="text-sm text-text-muted">
+                          {new Date(publishedAt).toLocaleDateString('id-ID', {
+                            year: 'numeric',
+                            month: 'long',
+                            day: 'numeric',
+                          })}
+                        </p>
+                        <h3 className="mt-2 text-lg font-semibold text-text">{post.title}</h3>
+                        <p className="mt-2 flex-grow text-sm text-text-muted">
+                          {description || 'Baca kisah terbaru dari TK Kartikasari.'}
+                        </p>
+                        <div className="mt-4 flex items-center text-sm font-semibold text-primary transition-transform group-hover:translate-x-1">
+                          Baca selengkapnya <ArrowRight className="ml-1 h-4 w-4" />
+                        </div>
+                      </div>
+                    </article>
+                  </Link>
+                );
+              })}
             </div>
           </AnimateIn>
         </PageSection>

--- a/lib/firebase-admin.ts
+++ b/lib/firebase-admin.ts
@@ -1,11 +1,29 @@
 
 import { getApps, initializeApp, cert } from 'firebase-admin/app';
+import type { App } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
+import type { Auth } from 'firebase-admin/auth';
 import { getFirestore } from 'firebase-admin/firestore';
+import type { Firestore } from 'firebase-admin/firestore';
 
-function initializeFirebaseAdmin() {
+function hasValidAdminConfig(): boolean {
+  return Boolean(
+    process.env.FIREBASE_PROJECT_ID &&
+      process.env.FIREBASE_CLIENT_EMAIL &&
+      process.env.FIREBASE_PRIVATE_KEY
+  );
+}
+
+function initializeFirebaseAdmin(): App | null {
   if (getApps().length) {
     return getApps()[0];
+  }
+
+  if (!hasValidAdminConfig()) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('Firebase Admin configuration is incomplete. Admin features are disabled.');
+    }
+    return null;
   }
 
   try {
@@ -19,12 +37,13 @@ function initializeFirebaseAdmin() {
     });
   } catch (error) {
     console.error('Firebase admin initialization error', error);
-    throw error;
+    return null;
   }
 }
 
 const adminApp = initializeFirebaseAdmin();
-const adminDb = getFirestore(adminApp);
-const adminAuth = getAuth(adminApp);
+const adminDb: Firestore | null = adminApp ? getFirestore(adminApp) : null;
+const adminAuth: Auth | null = adminApp ? getAuth(adminApp) : null;
 
 export { adminDb, adminAuth };
+export const isFirebaseAdminConfigured = () => Boolean(adminApp);

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,8 +1,12 @@
 
 import { initializeApp, getApps, getApp } from "firebase/app";
+import type { FirebaseApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
+import type { Firestore } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
+import type { Auth } from "firebase/auth";
 import { getStorage } from "firebase/storage";
+import type { FirebaseStorage } from "firebase/storage";
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -13,10 +17,73 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
-// Initialize Firebase
-const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
-const db = getFirestore(app);
-const auth = getAuth(app);
-const storage = getStorage(app);
+function hasValidConfig(): boolean {
+  return Object.values(firebaseConfig).every((value) => typeof value === "string" && value.length > 0);
+}
 
-export { app, db, auth, storage };
+let firebaseApp: FirebaseApp | null = null;
+let firestoreInstance: Firestore | null = null;
+let authInstance: Auth | null = null;
+let storageInstance: FirebaseStorage | null = null;
+
+export function isFirebaseConfigured(): boolean {
+  return hasValidConfig();
+}
+
+export function getFirebaseApp(): FirebaseApp | null {
+  if (!hasValidConfig()) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("Firebase configuration is incomplete. Firebase services are disabled.");
+    }
+    return null;
+  }
+
+  if (firebaseApp) {
+    return firebaseApp;
+  }
+
+  firebaseApp = getApps().length ? getApp() : initializeApp(firebaseConfig);
+  return firebaseApp;
+}
+
+export function getFirestoreDb(): Firestore | null {
+  if (firestoreInstance) {
+    return firestoreInstance;
+  }
+
+  const app = getFirebaseApp();
+  if (!app) {
+    return null;
+  }
+
+  firestoreInstance = getFirestore(app);
+  return firestoreInstance;
+}
+
+export function getFirebaseAuth(): Auth | null {
+  if (authInstance) {
+    return authInstance;
+  }
+
+  const app = getFirebaseApp();
+  if (!app) {
+    return null;
+  }
+
+  authInstance = getAuth(app);
+  return authInstance;
+}
+
+export function getFirebaseStorage(): FirebaseStorage | null {
+  if (storageInstance) {
+    return storageInstance;
+  }
+
+  const app = getFirebaseApp();
+  if (!app) {
+    return null;
+  }
+
+  storageInstance = getStorage(app);
+  return storageInstance;
+}


### PR DESCRIPTION
## Summary
- add an API route and update the middleware to verify session cookies without importing firebase-admin in the Edge runtime
- refactor Firebase client and admin helpers to initialize lazily, guard against missing configuration, and return safe fallbacks across the app
- harden blog and legal pages plus the admin dashboard to handle absent Firestore data while preserving existing UI content

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d769fdd16c832f839cb281c19f22f5