### PR TITLE
Add local admin auth fallback and refresh admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ Untuk menjalankan proyek ini di komputer Anda:
 
     Buka [http://localhost:3000](http://localhost:3000) di browser Anda untuk melihat hasilnya.
 
+## Akses Admin & Autentikasi
+
+-   **Kredensial Default:** Email `tkkartikasari@gmail.com` dengan password `clp1998` dapat digunakan untuk mengelola dasbor admin.
+-   **Keamanan Tambahan:** Gantilah kredensial default melalui variabel lingkungan `ADMIN_EMAIL` dan `ADMIN_PASSWORD_HASH` (gunakan format `salt:hash` hasil fungsi `scrypt`).
+-   **Session Secret:** Tetapkan nilai khusus pada `SESSION_SECRET` untuk menandatangani cookie sesi ketika menjalankan aplikasi di lingkungan produksi.
+-   **Integrasi Firebase (Opsional):** Jika Firebase Auth dan Firebase Admin dikonfigurasi, sistem akan otomatis menggunakan autentikasi Firebase serta sesi berbasis ID token.
+
 ## Lisensi
 
 Proyek ini dilisensikan di bawah [MIT License](LICENSE).

--- a/app/admin/blog/page.tsx
+++ b/app/admin/blog/page.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import { addDoc, collection, deleteDoc, doc, onSnapshot, orderBy, query, serverTimestamp } from 'firebase/firestore';
 import { getDownloadURL, ref, uploadBytes } from 'firebase/storage';
 import { getFirestoreDb, getFirebaseStorage } from '@/lib/firebase';
+import { AdminShell } from '@/components/admin/AdminShell';
 import { slugify } from '@/utils/slugify';
 
 interface BlogPost {
@@ -243,31 +244,38 @@ export default function BlogManagementPage() {
   }, [firestore]);
 
   return (
-    <main className="container mx-auto py-8">
-      <h1 className="mb-8 text-3xl font-bold">Kelola Blog & Kegiatan</h1>
+    <AdminShell
+      title="Blog & Kegiatan"
+      description="Kelola berita sekolah, unggah dokumentasi, dan atur jadwal publikasi."
+    >
+      <div className="space-y-12">
+        {message && (
+          <div
+            className={`rounded-lg border p-4 text-sm ${
+              messageType === 'error'
+                ? 'border-red-200 bg-red-50 text-red-700'
+                : messageType === 'success'
+                  ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                  : 'border-primary/20 bg-primary/5 text-primary'
+            }`}
+          >
+            {message}
+          </div>
+        )}
 
-      {message && (
-        <div
-          className={`mb-6 rounded-md border p-4 text-sm ${
-            messageType === 'error'
-              ? 'border-red-200 bg-red-50 text-red-700'
-              : messageType === 'success'
-                ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
-                : 'border-primary/20 bg-primary/5 text-primary'
-          }`}
-        >
-          {message}
-        </div>
-      )}
-
-      <section className="mb-12">
-        <h2 className="mb-4 text-2xl font-semibold">Tambah Postingan Baru</h2>
-        <form onSubmit={handleSubmit} className="space-y-6">
-          <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700" htmlFor={titleFieldId}>
-              Judul*
-            </label>
-            <input
+        <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h2 className="text-xl font-semibold text-slate-900">Tambah Postingan Baru</h2>
+          <p className="mt-2 text-sm text-slate-600">
+            Lengkapi formulir berikut untuk mempublikasikan berita atau dokumentasi kegiatan.
+            Semua konten mendukung format Markdown sehingga mudah untuk menambahkan gambar dan
+            penekanan teks.
+          </p>
+          <form onSubmit={handleSubmit} className="mt-6 space-y-6">
+            <div>
+              <label className="mb-2 block text-sm font-medium text-gray-700" htmlFor={titleFieldId}>
+                Judul*
+              </label>
+              <input
               type="text"
               id={titleFieldId}
               value={form.title}
@@ -405,62 +413,70 @@ export default function BlogManagementPage() {
               {isSubmitting ? 'Menyimpan...' : 'Simpan Postingan'}
             </button>
           </div>
-        </form>
-      </section>
+          </form>
+        </section>
 
-      <section>
-        <h2 className="mb-4 text-2xl font-semibold">Daftar Postingan</h2>
-        {posts.length === 0 ? (
-          <p className="text-sm text-gray-500">Belum ada data postingan. Silakan tambah postingan baru.</p>
-        ) : (
-          <div className="overflow-hidden rounded-lg border border-gray-200">
-            <table className="min-w-full divide-y divide-gray-200 text-left text-sm">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th className="px-4 py-3 font-semibold text-gray-600">Judul</th>
-                  <th className="px-4 py-3 font-semibold text-gray-600">Tanggal</th>
-                  <th className="px-4 py-3 font-semibold text-gray-600">Slug</th>
-                  <th className="px-4 py-3 text-right font-semibold text-gray-600">Aksi</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100 bg-white">
-                {posts.map((post) => (
-                  <tr key={post.id} className="hover:bg-gray-50">
-                    <td className="px-4 py-3 font-medium text-gray-800">{post.title}</td>
-                    <td className="px-4 py-3 text-gray-600">
-                      {new Date(post.date).toLocaleDateString('id-ID', {
-                        year: 'numeric',
-                        month: 'long',
-                        day: 'numeric',
-                      })}
-                    </td>
-                    <td className="px-4 py-3 text-gray-500">{post.slug}</td>
-                    <td className="px-4 py-3 text-right">
-                      <div className="flex items-center justify-end gap-2">
-                        <Link
-                          href={`/blog/${post.slug}`}
-                          className="rounded-md border border-primary px-3 py-1 text-sm font-medium text-primary transition hover:bg-primary hover:text-white"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          Lihat
-                        </Link>
-                        <button
-                          type="button"
-                          onClick={() => handleDelete(post.id)}
-                          className="rounded-md border border-red-200 px-3 py-1 text-sm font-medium text-red-600 transition hover:bg-red-50"
-                        >
-                          Hapus
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+        <section>
+          <div className="flex items-center justify-between gap-4">
+            <h2 className="text-xl font-semibold text-slate-900">Daftar Postingan</h2>
+            <p className="text-xs uppercase tracking-wide text-slate-500">
+              Total {posts.length} postingan
+            </p>
           </div>
-        )}
-      </section>
-    </main>
+          {posts.length === 0 ? (
+            <p className="mt-4 rounded-lg border border-dashed border-slate-300 bg-slate-50 p-6 text-sm text-slate-500">
+              Belum ada data postingan. Silakan tambah postingan baru untuk mengisi daftar ini.
+            </p>
+          ) : (
+            <div className="mt-6 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+              <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+                <thead className="bg-slate-50">
+                  <tr>
+                    <th className="px-4 py-3 font-semibold text-slate-600">Judul</th>
+                    <th className="px-4 py-3 font-semibold text-slate-600">Tanggal</th>
+                    <th className="px-4 py-3 font-semibold text-slate-600">Slug</th>
+                    <th className="px-4 py-3 text-right font-semibold text-slate-600">Aksi</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {posts.map((post) => (
+                    <tr key={post.id} className="bg-white transition hover:bg-slate-50">
+                      <td className="px-4 py-3 font-medium text-slate-900">{post.title}</td>
+                      <td className="px-4 py-3 text-slate-600">
+                        {new Date(post.date).toLocaleDateString('id-ID', {
+                          year: 'numeric',
+                          month: 'long',
+                          day: 'numeric',
+                        })}
+                      </td>
+                      <td className="px-4 py-3 text-slate-500">{post.slug}</td>
+                      <td className="px-4 py-3 text-right">
+                        <div className="flex items-center justify-end gap-2">
+                          <Link
+                            href={`/blog/${post.slug}`}
+                            className="rounded-md border border-primary px-3 py-1 text-sm font-medium text-primary transition hover:bg-primary hover:text-white"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            Lihat
+                          </Link>
+                          <button
+                            type="button"
+                            onClick={() => handleDelete(post.id)}
+                            className="rounded-md border border-red-200 px-3 py-1 text-sm font-medium text-red-600 transition hover:bg-red-50"
+                          >
+                            Hapus
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      </div>
+    </AdminShell>
   );
 }

--- a/app/admin/content/page.tsx
+++ b/app/admin/content/page.tsx
@@ -1,10 +1,23 @@
 
+import { AdminShell } from '@/components/admin/AdminShell';
+
 export default function ContentManagementPage() {
   return (
-    <main className="container mx-auto py-8">
-      <h1 className="mb-8 text-3xl font-bold">Content Management</h1>
-      <p>Here you will be able to edit the content of your website.</p>
-      {/* Content editing form will go here */}
-    </main>
+    <AdminShell
+      title="Kelola Konten"
+      description="Perbarui teks halaman utama, profil sekolah, dan informasi penting lainnya."
+    >
+      <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <p className="text-sm text-slate-600">
+          Editor konten terpusat akan hadir di sini. Sementara ini, koordinasikan dengan tim
+          pengembang untuk memperbarui konten statis melalui berkas Markdown pada repositori.
+        </p>
+        <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-slate-600">
+          <li>Konten halaman utama berada di folder <code>content/homepage</code>.</li>
+          <li>Gunakan format Markdown sederhana agar konsisten dengan tampilan situs.</li>
+          <li>Simpan perubahan dan jalankan proses build untuk menerapkan pembaruan.</li>
+        </ul>
+      </div>
+    </AdminShell>
   );
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,25 +1,74 @@
 
 import Link from 'next/link';
+import { AdminShell } from '@/components/admin/AdminShell';
+
+const quickLinks = [
+  {
+    href: '/admin/content',
+    title: 'Kelola Konten',
+    description: 'Perbarui hero, profil sekolah, dan informasi penting lainnya.',
+    cta: 'Buka editor konten',
+  },
+  {
+    href: '/admin/blog',
+    title: 'Blog & Kegiatan',
+    description: 'Tambah dokumentasi kegiatan terbaru beserta foto pendukung.',
+    cta: 'Kelola berita',
+  },
+];
 
 export default function AdminPage() {
   return (
-    <main className="container mx-auto py-8">
-      <h1 className="mb-8 text-4xl font-bold">Admin Panel</h1>
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-        <Link href="/admin/content">
-          <div className="block rounded-lg border border-gray-200 bg-white p-6 shadow-md transition-shadow duration-300 hover:shadow-lg">
-            <h2 className="mb-2 text-2xl font-semibold">Content Management</h2>
-            <p className="text-gray-600">Edit the text content of your website&apos;s pages.</p>
+    <AdminShell
+      title="Dasbor Utama"
+      description="Kelola seluruh informasi TK Kartika Sari dari satu tempat."
+    >
+      <div className="grid gap-6 lg:grid-cols-2">
+        {quickLinks.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="group flex h-full flex-col justify-between rounded-xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+          >
+            <div>
+              <h3 className="text-xl font-semibold text-slate-900 group-hover:text-indigo-700">
+                {item.title}
+              </h3>
+              <p className="mt-2 text-sm text-slate-600">{item.description}</p>
+            </div>
+            <span className="mt-6 inline-flex items-center text-sm font-semibold text-indigo-600">
+              {item.cta}
+              <svg
+                className="ml-2 h-4 w-4"
+                viewBox="0 0 16 16"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+              >
+                <path
+                  d="M5.5 3.5L10.5 8L5.5 12.5"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </span>
+          </Link>
+        ))}
+        <div className="flex flex-col justify-between rounded-xl border border-dashed border-slate-300 bg-slate-50 p-6 text-slate-600">
+          <div>
+            <h3 className="text-xl font-semibold text-slate-900">Butuh modul baru?</h3>
+            <p className="mt-2 text-sm">
+              Hubungi pengembang untuk menambahkan modul administrasi lainnya seperti manajemen
+              galeri, pendaftaran PPDB, atau laporan keuangan.
+            </p>
           </div>
-        </Link>
-        <Link href="/admin/blog">
-          <div className="block rounded-lg border border-gray-200 bg-white p-6 shadow-md transition-shadow duration-300 hover:shadow-lg">
-            <h2 className="mb-2 text-2xl font-semibold">Blog &amp; Kegiatan</h2>
-            <p className="text-gray-600">Buat postingan baru, unggah gambar, dan kelola berita terbaru.</p>
-          </div>
-        </Link>
-        {/* Other admin sections can be added here in the future */}
+          <p className="mt-6 text-sm text-slate-500">
+            Tips: susun checklist internal agar pembaruan informasi sekolah tetap konsisten.
+          </p>
+        </div>
       </div>
-    </main>
+    </AdminShell>
   );
 }

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  const response = NextResponse.json({ status: 'success' });
+  response.cookies.set('session', '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 0,
+    expires: new Date(0),
+  });
+  return response;
+}

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,33 +1,83 @@
 
 import { NextResponse } from 'next/server';
-import { adminAuth } from '@/lib/firebase-admin';
+import { adminAuth, isFirebaseAdminConfigured } from '@/lib/firebase-admin';
+import {
+  isLocalAuthConfigured,
+  verifyLocalAdminCredentials,
+} from '@/lib/local-auth';
+import { createLocalSessionToken } from '@/lib/local-session';
 
 export async function POST(request: Request) {
   try {
-    if (!adminAuth) {
-      return NextResponse.json({ status: 'error', message: 'Firebase admin is not configured.' }, { status: 500 });
-    }
-
-    const { idToken } = await request.json();
+    const body = await request.json();
 
     // Set session expiration to 5 days.
-    const expiresIn = 60 * 60 * 24 * 5 * 1000;
-    
-    // Create the session cookie. This will also verify the ID token.
-    const sessionCookie = await adminAuth.createSessionCookie(idToken, { expiresIn });
+    const expiresInMs = 60 * 60 * 24 * 5 * 1000;
+    const cookieMaxAgeSeconds = Math.floor(expiresInMs / 1000);
+    const cookieExpires = new Date(Date.now() + expiresInMs);
 
-    // Set cookie policy for session cookie.
-    const options = { 
-      name: 'session', 
-      value: sessionCookie, 
-      maxAge: expiresIn, 
-      httpOnly: true, 
-      secure: true 
-    };
+    if (isFirebaseAdminConfigured() && adminAuth) {
+      const { idToken } = body;
 
-    // Add the cookie to the response
-    const response = NextResponse.json({ status: 'success' });
-    response.cookies.set(options.name, options.value, options);
+      if (!idToken) {
+        return NextResponse.json(
+          { status: 'error', message: 'Missing Firebase ID token.' },
+          { status: 400 }
+        );
+      }
+
+      // Create the session cookie. This will also verify the ID token.
+      const sessionCookie = await adminAuth.createSessionCookie(idToken, { expiresIn: expiresInMs });
+
+      const response = NextResponse.json({ status: 'success', type: 'firebase' });
+      response.cookies.set('session', sessionCookie, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        maxAge: cookieMaxAgeSeconds,
+        expires: cookieExpires,
+      });
+
+      return response;
+    }
+
+    const { email, password } = body;
+
+    if (!isLocalAuthConfigured()) {
+      return NextResponse.json(
+        { status: 'error', message: 'Local authentication is not configured.' },
+        { status: 500 }
+      );
+    }
+
+    if (!email || !password || typeof email !== 'string' || typeof password !== 'string') {
+      return NextResponse.json(
+        { status: 'error', message: 'Email dan password wajib diisi.' },
+        { status: 400 }
+      );
+    }
+
+    if (!verifyLocalAdminCredentials(email, password)) {
+      return NextResponse.json(
+        { status: 'error', message: 'Email atau password salah.' },
+        { status: 401 }
+      );
+    }
+
+    const sessionToken = createLocalSessionToken({
+      email,
+      role: 'admin',
+      exp: Date.now() + expiresInMs,
+    });
+
+    const response = NextResponse.json({ status: 'success', type: 'local' });
+    response.cookies.set('session', sessionToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: cookieMaxAgeSeconds,
+      expires: cookieExpires,
+    });
 
     return response;
 

--- a/app/api/auth/verify/route.ts
+++ b/app/api/auth/verify/route.ts
@@ -1,15 +1,13 @@
 import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
-import { adminAuth } from '@/lib/firebase-admin';
+import { adminAuth, isFirebaseAdminConfigured } from '@/lib/firebase-admin';
+import { isLocalAuthConfigured } from '@/lib/local-auth';
+import { verifyLocalSessionToken } from '@/lib/local-session';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
-  if (!adminAuth) {
-    return NextResponse.json({ status: 'error', message: 'Firebase admin is not configured.' }, { status: 500 });
-  }
-
   const cookieStore = await cookies();
   const sessionCookie = cookieStore.get('session')?.value;
 
@@ -18,8 +16,25 @@ export async function GET() {
   }
 
   try {
-    await adminAuth.verifySessionCookie(sessionCookie, true /** checkRevoked */);
-    return NextResponse.json({ status: 'success' });
+    if (isFirebaseAdminConfigured() && adminAuth) {
+      await adminAuth.verifySessionCookie(sessionCookie, true /** checkRevoked */);
+      return NextResponse.json({ status: 'success', type: 'firebase' });
+    }
+
+    if (!isLocalAuthConfigured()) {
+      return NextResponse.json(
+        { status: 'error', message: 'Authentication is not configured.' },
+        { status: 500 }
+      );
+    }
+
+    const payload = verifyLocalSessionToken(sessionCookie);
+
+    if (!payload) {
+      return NextResponse.json({ status: 'error', message: 'Invalid session' }, { status: 401 });
+    }
+
+    return NextResponse.json({ status: 'success', type: 'local' });
   } catch (error) {
     console.error('Session verification error:', error);
     return NextResponse.json({ status: 'error', message: 'Invalid session' }, { status: 401 });

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,51 +4,82 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { signInWithEmailAndPassword } from 'firebase/auth';
-import { getFirebaseAuth } from '@/lib/firebase';
+import { getFirebaseAuth, isFirebaseConfigured } from '@/lib/firebase';
 
 export default function LoginPage() {
   const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const firebaseEnabled = isFirebaseConfigured();
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    setIsSubmitting(true);
 
     try {
-      const auth = getFirebaseAuth();
-      if (!auth) {
-        throw new Error('Firebase Auth belum dikonfigurasi.');
-      }
+      if (firebaseEnabled) {
+        const auth = getFirebaseAuth();
+        if (!auth) {
+          throw new Error('Firebase Auth belum dikonfigurasi.');
+        }
 
-      const userCredential = await signInWithEmailAndPassword(auth, email, password);
-      const user = userCredential.user;
-      const idToken = await user.getIdToken();
+        const userCredential = await signInWithEmailAndPassword(auth, email, password);
+        const user = userCredential.user;
+        const idToken = await user.getIdToken();
+
+        const response = await fetch('/api/auth/session', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ idToken }),
+        });
+
+        if (response.ok) {
+          router.push('/admin');
+        } else {
+          const data = await response.json();
+          setError(data.message || 'Login failed');
+        }
+        return;
+      }
 
       const response = await fetch('/api/auth/session', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ idToken }),
+        body: JSON.stringify({ email, password }),
       });
 
       if (response.ok) {
         router.push('/admin');
       } else {
         const data = await response.json();
-        setError(data.message || 'Login failed');
+        setError(data.message || 'Login gagal');
       }
     } catch (error: any) {
-      setError(error.message || 'An unknown error occurred');
+      setError(error.message || 'Terjadi kesalahan saat masuk.');
     }
+
+    setIsSubmitting(false);
   };
 
   return (
     <main className="container mx-auto flex min-h-screen items-center justify-center">
       <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-md">
         <h1 className="mb-6 text-center text-3xl font-bold">Admin Login</h1>
+        {!firebaseEnabled && (
+          <p className="mb-6 rounded-md bg-indigo-50 p-3 text-sm text-indigo-700">
+            Gunakan akun admin yang disediakan untuk mengakses dasbor. Kredensial dapat
+            dikonfigurasi melalui variabel lingkungan <code>ADMIN_EMAIL</code> dan
+            <code>ADMIN_PASSWORD_HASH</code>.
+          </p>
+        )}
         <form onSubmit={handleLogin}>
           <div className="mb-4">
             <label htmlFor="email" className="mb-2 block text-sm font-medium text-gray-700">
@@ -79,9 +110,10 @@ export default function LoginPage() {
           {error && <p className="mb-4 text-sm text-red-600">{error}</p>}
           <button
             type="submit"
-            className="w-full rounded-md bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            disabled={isSubmitting}
+            className="w-full rounded-md bg-indigo-600 px-4 py-2 text-white transition hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-indigo-300"
           >
-            Login
+            {isSubmitting ? 'Memproses...' : 'Login'}
           </button>
         </form>
       </div>

--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useMemo, useState, type ChangeEvent, type ReactNode } from 'react';
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+
+interface NavigationItem {
+  href: string;
+  label: string;
+  description?: string;
+}
+
+interface AdminShellProps {
+  title: string;
+  description?: string;
+  children: ReactNode;
+}
+
+const NAVIGATION_ITEMS: NavigationItem[] = [
+  {
+    href: '/admin',
+    label: 'Dasbor',
+    description: 'Ringkasan cepat modul administrasi.',
+  },
+  {
+    href: '/admin/content',
+    label: 'Kelola Konten',
+    description: 'Perbarui informasi statis dan halaman utama.',
+  },
+  {
+    href: '/admin/blog',
+    label: 'Blog & Kegiatan',
+    description: 'Publikasikan berita terbaru dan dokumentasi kegiatan.',
+  },
+];
+
+export function AdminShell({ title, description, children }: AdminShellProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  const activeHref = useMemo(() => {
+    return (
+      NAVIGATION_ITEMS.find((item) =>
+        item.href === '/admin'
+          ? pathname === '/admin'
+          : pathname?.startsWith(item.href)
+      )?.href ?? '/admin'
+    );
+  }, [pathname]);
+
+  const handleNavigationChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value;
+    if (value && value !== pathname) {
+      router.push(value);
+    }
+  };
+
+  const handleLogout = async () => {
+    try {
+      setIsLoggingOut(true);
+      const response = await fetch('/api/auth/logout', { method: 'POST' });
+      if (response.ok) {
+        router.push('/login');
+      }
+    } finally {
+      setIsLoggingOut(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen bg-slate-50">
+      <aside className="hidden w-72 flex-shrink-0 border-r border-slate-200 bg-white md:flex md:flex-col">
+        <div className="border-b border-slate-200 px-6 py-6">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">TK Kartika Sari</p>
+          <h1 className="text-xl font-bold text-slate-900">Dasbor Admin</h1>
+        </div>
+        <nav className="flex-1 space-y-1 px-3 py-4">
+          {NAVIGATION_ITEMS.map((item) => {
+            const isActive =
+              item.href === '/admin'
+                ? activeHref === item.href
+                : pathname?.startsWith(item.href);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`block rounded-lg px-4 py-3 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 ${
+                  isActive
+                    ? 'bg-indigo-50 text-indigo-700 ring-1 ring-indigo-100'
+                    : 'text-slate-600 hover:bg-slate-50 hover:text-slate-900'
+                }`}
+              >
+                <p className="text-sm font-semibold">{item.label}</p>
+                {item.description && (
+                  <p className="text-xs text-slate-500">{item.description}</p>
+                )}
+              </Link>
+            );
+          })}
+        </nav>
+        <div className="border-t border-slate-200 px-6 py-4 text-sm text-slate-500">
+          <p>Kamu masuk sebagai admin.</p>
+        </div>
+      </aside>
+      <div className="flex min-h-screen flex-1 flex-col">
+        <header className="border-b border-slate-200 bg-white px-4 py-4 shadow-sm sm:px-6">
+          <div className="mb-3 md:hidden">
+            <label htmlFor="admin-navigation" className="sr-only">
+              Navigasi admin
+            </label>
+            <select
+              id="admin-navigation"
+              className="block w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              value={activeHref}
+              onChange={handleNavigationChange}
+            >
+              {NAVIGATION_ITEMS.map((item) => (
+                <option key={item.href} value={item.href}>
+                  {item.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-2xl font-bold text-slate-900">{title}</h2>
+              {description && <p className="text-sm text-slate-600">{description}</p>}
+            </div>
+            <button
+              type="button"
+              onClick={handleLogout}
+              disabled={isLoggingOut}
+              className="inline-flex items-center justify-center rounded-md border border-transparent bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-900 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:bg-slate-400"
+            >
+              {isLoggingOut ? 'Keluar...' : 'Keluar'}
+            </button>
+          </div>
+        </header>
+        <main className="flex-1 px-4 py-6 sm:px-6 lg:px-8">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/lib/local-auth.ts
+++ b/lib/local-auth.ts
@@ -1,0 +1,54 @@
+import { scryptSync, timingSafeEqual } from 'crypto';
+
+const DEFAULT_ADMIN_EMAIL = 'tkkartikasari@gmail.com';
+const DEFAULT_ADMIN_PASSWORD_HASH =
+  'b0451a92f2075260ddc0090d47162f40:2692c72af71a3a37ffa090da1d8af232410b1f27a56e3f7a68d7c5f8ab85f231497965be399a2da86f8a09159e66db20319500cb895a4291cb52c392df5ae936';
+
+const HASH_DELIMITER = ':';
+const DERIVED_KEY_LENGTH = 64;
+
+export interface LocalAdminCredentialConfig {
+  email: string;
+  passwordHash: string;
+}
+
+export function getLocalAdminCredentials(): LocalAdminCredentialConfig {
+  return {
+    email: process.env.ADMIN_EMAIL?.trim() || DEFAULT_ADMIN_EMAIL,
+    passwordHash: process.env.ADMIN_PASSWORD_HASH?.trim() || DEFAULT_ADMIN_PASSWORD_HASH,
+  };
+}
+
+export function isLocalAuthConfigured(): boolean {
+  const { email, passwordHash } = getLocalAdminCredentials();
+  return Boolean(email && passwordHash && passwordHash.includes(HASH_DELIMITER));
+}
+
+export function verifyLocalAdminCredentials(email: string, password: string): boolean {
+  if (!isLocalAuthConfigured()) {
+    return false;
+  }
+
+  const { email: expectedEmail, passwordHash } = getLocalAdminCredentials();
+
+  if (email.trim().toLowerCase() !== expectedEmail.toLowerCase()) {
+    return false;
+  }
+
+  const [salt, storedHash] = passwordHash.split(HASH_DELIMITER);
+
+  if (!salt || !storedHash) {
+    return false;
+  }
+
+  const derived = scryptSync(password, salt, DERIVED_KEY_LENGTH).toString('hex');
+
+  const storedHashBuffer = Buffer.from(storedHash, 'hex');
+  const derivedBuffer = Buffer.from(derived, 'hex');
+
+  if (storedHashBuffer.length !== derivedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(storedHashBuffer, derivedBuffer);
+}

--- a/lib/local-session.ts
+++ b/lib/local-session.ts
@@ -1,0 +1,59 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+const DEFAULT_SESSION_SECRET = 'change-me-in-production';
+
+export interface LocalSessionPayload {
+  email: string;
+  role: 'admin';
+  exp: number; // Unix epoch in milliseconds
+}
+
+function getSessionSecret(): string {
+  return process.env.SESSION_SECRET?.trim() || DEFAULT_SESSION_SECRET;
+}
+
+export function createLocalSessionToken(payload: LocalSessionPayload): string {
+  const secret = getSessionSecret();
+  const data = JSON.stringify(payload);
+  const signature = createHmac('sha256', secret).update(data).digest('hex');
+  const token = `${data}.${signature}`;
+  return Buffer.from(token).toString('base64url');
+}
+
+export function verifyLocalSessionToken(token: string): LocalSessionPayload | null {
+  try {
+    const secret = getSessionSecret();
+    const decoded = Buffer.from(token, 'base64url').toString('utf-8');
+    const separatorIndex = decoded.lastIndexOf('.');
+
+    if (separatorIndex === -1) {
+      return null;
+    }
+
+    const data = decoded.slice(0, separatorIndex);
+    const signature = decoded.slice(separatorIndex + 1);
+    const expectedSignature = createHmac('sha256', secret).update(data).digest('hex');
+
+    const signatureBuffer = Buffer.from(signature, 'hex');
+    const expectedBuffer = Buffer.from(expectedSignature, 'hex');
+
+    if (signatureBuffer.length !== expectedBuffer.length) {
+      return null;
+    }
+
+    if (!timingSafeEqual(signatureBuffer, expectedBuffer)) {
+      return null;
+    }
+
+    const payload = JSON.parse(data) as LocalSessionPayload;
+
+    if (typeof payload.exp !== 'number' || Date.now() > payload.exp) {
+      return null;
+    }
+
+    return payload;
+  } catch (error) {
+    console.error('Failed to verify local session token', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add a local authentication fallback with hashed default admin credentials and signed session cookies, including a logout endpoint
- document admin access configuration and improve the admin login UX
- refresh the admin dashboard layout with reusable navigation and updated content/blog management shells

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7715537f0832fb3b81660d88eb93b