### PR TITLE
Fix admin login validation and redact credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ Untuk menjalankan proyek ini di komputer Anda:
 
 ## Akses Admin & Autentikasi
 
--   **Kredensial Default:** Email `tkkartikasari@gmail.com` dengan password `clp1998` dapat digunakan untuk mengelola dasbor admin.
--   **Keamanan Tambahan:** Gantilah kredensial default melalui variabel lingkungan `ADMIN_EMAIL` dan `ADMIN_PASSWORD_HASH` (gunakan format `salt:hash` hasil fungsi `scrypt`).
+-   **Kredensial Admin:** Akun admin dikelola melalui variabel lingkungan `ADMIN_EMAIL` dan `ADMIN_PASSWORD_HASH` (gunakan format `salt:hash` hasil fungsi `scrypt`). Simpan nilai tersebut secara privat dan jangan menuliskannya di repositori publik.
 -   **Session Secret:** Tetapkan nilai khusus pada `SESSION_SECRET` untuk menandatangani cookie sesi ketika menjalankan aplikasi di lingkungan produksi.
 -   **Integrasi Firebase (Opsional):** Jika Firebase Auth dan Firebase Admin dikonfigurasi, sistem akan otomatis menggunakan autentikasi Firebase serta sesi berbasis ID token.
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -21,13 +21,25 @@ export default function LoginPage() {
     setIsSubmitting(true);
 
     try {
+      const sanitizedEmail = email.trim();
+      const sanitizedPassword = password;
+
+      if (!sanitizedEmail || !sanitizedPassword) {
+        setError('Email dan password wajib diisi.');
+        return;
+      }
+
       if (firebaseEnabled) {
         const auth = getFirebaseAuth();
         if (!auth) {
           throw new Error('Firebase Auth belum dikonfigurasi.');
         }
 
-        const userCredential = await signInWithEmailAndPassword(auth, email, password);
+        const userCredential = await signInWithEmailAndPassword(
+          auth,
+          sanitizedEmail,
+          sanitizedPassword
+        );
         const user = userCredential.user;
         const idToken = await user.getIdToken();
 
@@ -53,7 +65,7 @@ export default function LoginPage() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ email, password }),
+        body: JSON.stringify({ email: sanitizedEmail, password: sanitizedPassword }),
       });
 
       if (response.ok) {
@@ -64,9 +76,9 @@ export default function LoginPage() {
       }
     } catch (error: any) {
       setError(error.message || 'Terjadi kesalahan saat masuk.');
+    } finally {
+      setIsSubmitting(false);
     }
-
-    setIsSubmitting(false);
   };
 
   return (


### PR DESCRIPTION
## Summary
- sanitize admin login input on the client and send trimmed credentials to the session endpoint
- harden the session API handler by safely parsing the request body, trimming credentials, and forcing the Node runtime
- update documentation to avoid publishing sensitive admin credentials

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d77b9479d4832fa0a3a608ec8f1b08