### PR TITLE
Close PPDB 2025/2026 intake messaging

### DIFF
--- a/app/ppdb/page.tsx
+++ b/app/ppdb/page.tsx
@@ -1,6 +1,6 @@
 
 import PageHeader from "@/components/layout/PageHeader";
-import { Check, CheckCircle, Clock, Person as User, Wallet, XCircle } from "react-bootstrap-icons";
+import { Check, CheckCircle, Clock, Person as User, Wallet } from "react-bootstrap-icons";
 import Link from "next/link";
 import PageSection from "@/components/layout/PageSection";
 import { formatRupiah } from "@/utils/currency";
@@ -40,24 +40,30 @@ export default async function PpdbPage() {
   return (
     <>
       <PageHeader
-        title="Penerimaan Peserta Didik Baru (PPDB) 2024/2025"
-        description="Jadilah bagian dari keluarga besar TK Kartikasari. Kami siap membimbing putra-putri Anda menjadi generasi pembelajar yang ceria, kreatif, dan berkarakter Pancasila."
-        eyebrow="PPDB 2024/2025"
+        title="Penerimaan Peserta Didik Baru (PPDB) 2025/2026"
+        description="Terima kasih atas antusiasme Ayah dan Bunda. Pendaftaran tatap muka untuk tahun ajaran 2025/2026 telah ditutup sejak awal Juli 2025 karena kuota telah terpenuhi."
+        eyebrow="PPDB 2025/2026"
       />
 
-      {/* Status Pendaftaran Ditutup */}
+      {/* Informasi Pendaftaran Tatap Muka */}
       <div className="content-container my-8">
-        <div className="rounded-2xl border border-yellow-500/30 bg-yellow-500/10 p-6">
+        <div className="rounded-2xl border border-primary/30 bg-primary/10 p-6">
           <div className="flex">
             <div className="flex-shrink-0">
-              <XCircle className="h-6 w-6 text-yellow-600" aria-hidden="true" />
+              <CheckCircle className="h-6 w-6 text-primary" aria-hidden="true" />
             </div>
             <div className="ml-4">
-              <h3 className="font-semibold text-yellow-800">Pendaftaran Telah Ditutup</h3>
-              <div className="mt-1 text-sm text-yellow-700">
+              <h3 className="font-semibold text-primary">PPDB 2025/2026 Ditutup</h3>
+              <div className="mt-1 space-y-2 text-sm text-text-muted">
                 <p>
-                  Terima kasih atas antusiasme Anda. Pendaftaran untuk tahun ajaran 2024/2025 telah kami tutup. Informasi pendaftaran untuk tahun ajaran berikutnya akan kami umumkan di halaman ini.
+                  Seluruh kursi untuk tahun ajaran 2025/2026 telah terisi per 5 Juli 2025. Kami tidak lagi menerima pendaftaran baru untuk periode ini.
                 </p>
+                <p>
+                  Ayah dan Bunda dapat menghubungi admin kami untuk masuk daftar tunggu atau mendapatkan pemberitahuan saat informasi PPDB 2026/2027 tersedia.
+                </p>
+                <Link href="/kontak" className="btn-secondary mt-4 inline-flex">
+                  Hubungi Admin PPDB
+                </Link>
               </div>
             </div>
           </div>
@@ -70,20 +76,22 @@ export default async function PpdbPage() {
           <div className="content-container py-16 sm:py-20">
             <div className="grid grid-cols-1 gap-12 lg:grid-cols-2 lg:gap-16">
               <div>
-                <h2 className="text-3xl font-bold tracking-tight text-text sm:text-4xl">Proses Pendaftaran Cepat & Mudah</h2>
-                <p className="mt-4 text-lg text-text-muted">Kami telah merancang proses pendaftaran yang sederhana agar Anda dapat fokus pada hal terpenting.</p>
+                <h2 className="text-3xl font-bold tracking-tight text-text sm:text-4xl">Rekap Proses Pendaftaran Tatap Muka</h2>
+                <p className="mt-4 text-lg text-text-muted">Gunakan ringkasan berikut sebagai gambaran proses PPDB tatap muka yang telah berlangsung. Informasi ini dapat membantu Ayah dan Bunda menyiapkan dokumen ketika periode berikutnya dibuka.</p>
                 <div className="mt-10 space-y-8">
-                  <Step icon={<User className="h-6 w-6 text-primary" />} title="Isi Formulir Singkat" description="Hanya butuh 5 menit untuk mengisi data anak dan orang tua." />
-                  <Step icon={<Wallet className="h-6 w-6 text-primary" />} title="Pembayaran Biaya Registrasi" description="Lakukan pembayaran biaya pendaftaran untuk mengamankan tempat anak Anda." />
-                  <Step icon={<CheckCircle className="h-6 w-6 text-primary" />} title="Konfirmasi & Selesai" description="Anda akan menerima konfirmasi instan melalui email dan WhatsApp." />
+                  <Step icon={<Clock className="h-6 w-6 text-primary" />} title="Jadwalkan Kunjungan" description="Hubungi admin kami melalui WhatsApp untuk memilih jadwal kunjungan yang cocok." />
+                  <Step icon={<User className="h-6 w-6 text-primary" />} title="Datang & Observasi" description="Ajak si kecil melihat kelas, bertemu guru, dan sampaikan pertanyaan seputar program belajar." />
+                  <Step icon={<Wallet className="h-6 w-6 text-primary" />} title="Lengkapi Administrasi di Tempat" description="Serahkan dokumen persyaratan, pilih opsi pembayaran, dan terima konfirmasi langsung dari tim administrasi." />
                 </div>
                 <div className="mt-12">
-                  <button className="btn-primary" disabled>Pendaftaran Telah Ditutup</button>
+                  <Link href="/kontak" className="btn-primary">
+                    Tanya Daftar Tunggu 2026/2027
+                  </Link>
                 </div>
               </div>
               <div className="rounded-2xl bg-surface p-8 shadow-lg">
-                <h3 className="text-2xl font-bold text-text">Timeline PPDB 2024/2025</h3>
-                <p className="mt-2 text-text-muted">Catat tanggal-tanggal penting berikut agar tidak terlewat.</p>
+                <h3 className="text-2xl font-bold text-text">Timeline PPDB 2025/2026 (Selesai)</h3>
+                <p className="mt-2 text-text-muted">Berikut rangkuman jadwal PPDB yang telah berlangsung. Jadwal terbaru akan kami umumkan mendekati tahun ajaran berikutnya.</p>
                 <Timeline items={timeline} />
                 <CountdownTimer targetDate={deadline} />
               </div>

--- a/components/home/HomePageContent.tsx
+++ b/components/home/HomePageContent.tsx
@@ -22,6 +22,11 @@ import { ArrowRight, CheckCircle } from "react-bootstrap-icons";
 import Link from "next/link";
 import Image from "next/image";
 import AnimateIn from "@/components/AnimateIn";
+import { homeJourney as homeJourneyStatic } from "@/content/home";
+import {
+  ppdbMetaDescription,
+  syaratDanKetentuan as ppdbRequirementsStatic,
+} from "@/content/ppdb";
 
 type HomePageContentProps = {
   schoolName: string;
@@ -54,6 +59,57 @@ export default function HomePageContent({
     stats.find((item) => item.label.toLowerCase().includes("rasio"))?.value ?? "1 : 8";
   const schoolNpsn = credentials.find((item) => item.label.toLowerCase() === "npsn")?.value;
 
+  const biayaRequirement = ppdbRequirementsStatic.find((item) =>
+    item.title.toLowerCase().includes("biaya"),
+  );
+  const documentRequirement = ppdbRequirementsStatic.find((item) =>
+    item.title.toLowerCase().includes("dokumen"),
+  );
+
+  const onboardingSteps = [
+    {
+      key: "routine",
+      href: "#pengalaman",
+      icon: "🧭",
+      title: "Kenali Rutinitas & Lingkungan",
+      description:
+        journey[0]?.description ??
+        homeJourneyStatic[0]?.description ??
+        "Lihat seperti apa agenda harian dan suasana pembelajaran yang menenangkan untuk si kecil.",
+      linkLabel: "Lihat rutinitas",
+    },
+    {
+      key: "cost",
+      href: "/biaya",
+      icon: "💡",
+      title: "Cek Perkiraan Biaya",
+      description:
+        biayaRequirement?.description ??
+        "Pelajari struktur biaya dan opsi pembayaran agar Ayah Bunda bisa merencanakan dengan tenang.",
+      linkLabel: "Lihat biaya",
+    },
+    {
+      key: "documents",
+      href: "/ppdb#requirements",
+      icon: "🗂️",
+      title: "Siapkan Dokumen Penting",
+      description:
+        documentRequirement?.description ??
+        "Siapkan dokumen dasar seperti akta kelahiran, KK, dan identitas orang tua untuk kelancaran administrasi.",
+      linkLabel: "Cek syarat",
+    },
+    {
+      key: "apply",
+      href: "/kontak",
+      icon: "📍",
+      title: "Diskusikan Ketersediaan Kuota",
+      description:
+        ppdbMetaDescription ??
+        "Hubungi admin TK Kartikasari untuk mengetahui status kuota terbaru, daftar tunggu, dan jadwal pembaruan PPDB.",
+      linkLabel: "Hubungi admin",
+    },
+  ] as const;
+
   return (
       <main>
         {/* Section 1: Hero (Kail) */}
@@ -83,7 +139,7 @@ export default function HomePageContent({
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
               <CTAButton ctaKey="heroVisit" />
               <Link href="/ppdb" className="btn-secondary w-full sm:w-auto">
-                Daftar Sekarang
+                Info PPDB
               </Link>
             </div>
             <div className="grid gap-6 pt-6 sm:grid-cols-2 md:grid-cols-3">
@@ -117,7 +173,67 @@ export default function HomePageContent({
           </AnimateIn>
         </PageSection>
 
-        {/* Section 2: Keunggulan/Highlights (Janji Utama) - REVISED */}
+        {/* Section 2: Langkah Onboarding */}
+        <PageSection
+          className="relative border-y border-white/50 bg-gradient-to-br from-primary/10 via-white to-secondary/10"
+          padding="tight"
+        >
+          <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+            <div className="absolute left-8 top-8 h-40 w-40 rounded-full bg-primary/20 blur-3xl" />
+            <div className="absolute right-12 bottom-12 h-48 w-48 rounded-full bg-secondary/20 blur-3xl" />
+          </div>
+          <AnimateIn className="relative">
+            <SectionHeader
+              align="center"
+              eyebrow="Mulai dari Sini"
+              eyebrowVariant="primary"
+              title="Alur singkat bergabung bersama TK Kartikasari"
+              description="Gunakan empat langkah ini sebagai panduan mengenal sekolah dan menyiapkan dokumen sebelum periode pendaftaran tatap muka berikutnya dibuka."
+            />
+          </AnimateIn>
+          <div className="relative mt-12 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+            {onboardingSteps.map((step, index) => (
+              <AnimateIn
+                key={step.key}
+                className="h-full"
+              >
+                <Link
+                  href={step.href}
+                  className="focus-visible-ring group flex h-full flex-col justify-between rounded-3xl border border-white/60 bg-white/70 p-7 text-left shadow-soft backdrop-blur-xl backdrop-saturate-150 transition-all duration-300 hover:-translate-y-1 hover:border-primary/60"
+                >
+                  <div>
+                    <span className="inline-flex items-center gap-3 rounded-full bg-primary/10 px-4 py-2 text-sm font-semibold text-primary">
+                      <span className="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-primary/15 text-base" aria-hidden="true">
+                        {index + 1}
+                      </span>
+                      Langkah {index + 1}
+                    </span>
+                    <div className="mt-6 flex items-start gap-3">
+                      <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-2xl" aria-hidden="true">
+                        {step.icon}
+                      </span>
+                      <div>
+                        <h3 className="text-lg font-semibold text-text">{step.title}</h3>
+                        <p className="mt-3 text-sm leading-relaxed text-text-muted">{step.description}</p>
+                      </div>
+                    </div>
+                  </div>
+                  <span className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-primary transition-transform group-hover:translate-x-1">
+                    {step.linkLabel} <ArrowRight className="h-4 w-4" />
+                  </span>
+                </Link>
+              </AnimateIn>
+            ))}
+          </div>
+          <div className="relative mt-12 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-center">
+            <Link href="/ppdb" className="btn-primary w-full sm:w-auto">
+              Info PPDB 2025/2026
+            </Link>
+            <CTAButton ctaKey="visitSchedule" className="w-full sm:w-auto" />
+          </div>
+        </PageSection>
+
+        {/* Section 3: Keunggulan/Highlights (Janji Utama) - REVISED */}
         <PageSection
           className="relative border-y border-white/50 bg-white/50 backdrop-blur-sm backdrop-saturate-150"
           padding="tight"

--- a/content/legal.ts
+++ b/content/legal.ts
@@ -6,7 +6,7 @@ export const kebijakanPrivasi = {
       <p>TK Kartikasari (\"kami\", \"milik kami\") berkomitmen untuk melindungi privasi informasi pribadi Anda. Kebijakan Privasi ini menjelaskan bagaimana kami mengumpulkan, menggunakan, dan melindungi informasi yang Anda berikan saat menggunakan website kami.</p>
       
       <h2>Informasi yang Kami Kumpulkan</h2>
-      <p>Kami dapat mengumpulkan informasi identifikasi pribadi dari Anda dalam berbagai cara, termasuk, namun tidak terbatas pada, saat Anda mengunjungi situs kami, mendaftar di formulir PPDB online, atau berinteraksi dengan fitur situs lainnya. Informasi yang mungkin dikumpulkan meliputi:</p>
+      <p>Kami dapat mengumpulkan informasi identifikasi pribadi dari Anda dalam berbagai cara, termasuk, namun tidak terbatas pada, saat Anda mengunjungi situs kami, menghubungi admin PPDB melalui WhatsApp, atau mengisi formulir pendaftaran offline di sekolah. Informasi yang mungkin dikumpulkan meliputi:</p>
       <ul class=\"list-disc list-inside space-y-1\">
         <li>Nama lengkap (Orang Tua & Anak)</li>
         <li>Alamat email</li>
@@ -44,13 +44,13 @@ export const syaratDanKetentuan = {
       <p>Selamat datang di website TK Kartikasari. Dengan mengakses atau menggunakan situs web ini, Anda setuju untuk terikat oleh Syarat dan Ketentuan berikut. Harap baca dokumen ini dengan saksama.</p>
 
       <h2>Penggunaan Situs</h2>
-      <p>Situs ini disediakan untuk tujuan informasi dan sebagai sarana pendaftaran online untuk sekolah kami. Anda setuju untuk menggunakan situs ini hanya untuk tujuan yang sah dan dengan cara yang tidak melanggar hak, atau membatasi atau menghambat penggunaan dan kenikmatan situs ini oleh pihak ketiga mana pun.</p>
+      <p>Situs ini disediakan untuk tujuan informasi mengenai sekolah kami dan proses pendaftaran. Anda setuju untuk menggunakan situs ini hanya untuk tujuan yang sah dan dengan cara yang tidak melanggar hak, atau membatasi atau menghambat penggunaan dan kenikmatan situs ini oleh pihak ketiga mana pun.</p>
 
       <h2>Kekayaan Intelektual</h2>
       <p>Semua konten yang disertakan di situs ini, seperti teks, grafik, logo, gambar, dan perangkat lunak, adalah milik TK Kartikasari atau pemasok kontennya dan dilindungi oleh undang-undang hak cipta. Penggunaan konten tanpa izin tertulis dari kami secara tegas dilarang.</p>
 
       <h2>Informasi Pendaftaran</h2>
-      <p>Dengan mengirimkan formulir pendaftaran melalui situs ini, Anda menjamin bahwa semua informasi yang diberikan adalah akurat, terkini, dan lengkap. Memberikan informasi yang tidak akurat dapat mengakibatkan penundaan atau penolakan pendaftaran.</p>
+      <p>Dengan menyerahkan dokumen pendaftaran kepada kami, Anda menjamin bahwa semua informasi yang diberikan adalah akurat, terkini, dan lengkap. Memberikan informasi yang tidak akurat dapat mengakibatkan penundaan atau penolakan pendaftaran.</p>
 
       <h2>Batasan Tanggung Jawab</h2>
       <p>Website dan kontennya disediakan \"sebagaimana adanya\". Meskipun kami berusaha untuk memberikan informasi yang akurat, kami tidak membuat jaminan apa pun, tersurat maupun tersirat, mengenai keakuratan, kelengkapan, atau keandalan informasi. TK Kartikasari tidak akan bertanggung jawab atas kerugian atau kerusakan apa pun yang timbul dari penggunaan situs ini.</p>

--- a/content/ppdb.ts
+++ b/content/ppdb.ts
@@ -5,12 +5,12 @@ export type PpdbFaq = {
 };
 
 export const ppdbMetaDescription =
-  "Pendaftaran siswa baru TK Kartikasari tahun ajaran 2024/2025 telah dibuka. Daftar online sekarang melalui formulir pendaftaran kami yang mudah dan cepat. Kuota terbatas!";
+  "Pendaftaran siswa baru TK Kartikasari tahun ajaran 2025/2026 telah ditutup. Hubungi admin kami untuk menanyakan daftar tunggu atau informasi periode penerimaan berikutnya.";
 
 export const syaratDanKetentuan = [
   {
     title: "Usia Calon Siswa",
-    description: "Minimal 4 tahun untuk Kelompok A dan 5 tahun untuk Kelompok B per 31 Juli 2024.",
+    description: "Minimal 4 tahun untuk Kelompok A dan 5 tahun untuk Kelompok B per 31 Juli 2025.",
   },
   {
     title: "Kelengkapan Dokumen",
@@ -28,9 +28,9 @@ export const syaratDanKetentuan = [
 
 export const ppdbFaqs: PpdbFaq[] = [
   {
-    question: "Bagaimana cara mendaftar secara online?",
+    question: "Bagaimana cara mendaftar?",
     answer:
-      "Cukup klik tombol 'Daftar Sekarang' di halaman ini, isi formulir data anak dan orang tua, lalu lakukan konfirmasi. Prosesnya hanya membutuhkan waktu sekitar 5-10 menit.",
+      "Silakan hubungi admin PPDB melalui WhatsApp untuk menjadwalkan kunjungan. Ayah/Bunda dapat membawa anak sekaligus menyerahkan dokumen saat datang ke sekolah.",
   },
   {
     question: "Apa saja yang termasuk dalam SPP bulanan?",
@@ -43,9 +43,9 @@ export const ppdbFaqs: PpdbFaq[] = [
       "Seluruh biaya pendaftaran dialokasikan langsung untuk proses administrasi dan memastikan kuota tidak terisi oleh calon lain. Oleh karena itu, biaya ini bersifat non-refundable. Kami sarankan untuk memastikan semua informasi sudah sesuai sebelum melakukan pembayaran.",
   },
   {
-    question: "Kapan saya akan dihubungi setelah mengirim formulir?",
+    question: "Kapan kami akan dihubungi setelah menyerahkan berkas?",
     answer:
-      "Salah satu perwakilan kami akan menghubungi Ayah/Bunda secara personal melalui WhatsApp dalam 1x24 jam pada hari kerja untuk memverifikasi data dan menjawab pertanyaan awal.",
+      "Tim administrasi akan mengonfirmasi penerimaan berkas dan jadwal tindak lanjut melalui WhatsApp maksimal 1x24 jam pada hari kerja.",
   },
   {
       question: "Apakah ada diskon untuk saudara kandung?",

--- a/lib/fallback-content.ts
+++ b/lib/fallback-content.ts
@@ -159,32 +159,32 @@ function mapCostStructure(): CostStructureItem[] {
 
 const fallbackPpdbTimeline = [
   {
-    date: "2024-06-01",
-    title: "Pendaftaran Dibuka",
+    date: "2025-05-27",
+    title: "Pendaftaran Tatap Muka Dibuka",
     description:
-      "Formulir online dan offline tersedia. Kuota terbatas, daftar segera!",
+      "Kunjungan dan penyerahan berkas di sekolah dimulai. Hubungi admin untuk membuat janji.",
   },
   {
-    date: "2024-07-15",
-    title: "Batas Akhir Pendaftaran",
-    description: "Pengumpulan formulir dan dokumen terakhir.",
+    date: "2025-07-05",
+    title: "Kuota PPDB Terpenuhi",
+    description: "Penerimaan ditutup karena seluruh kursi tahun ajaran 2025/2026 telah terisi.",
   },
   {
-    date: "2024-07-18",
-    title: "Pengumuman Seleksi",
+    date: "2025-07-08",
+    title: "Konfirmasi Peserta",
     description:
-      "Hasil seleksi akan diumumkan di website dan papan pengumuman sekolah.",
+      "Tim administrasi menghubungi keluarga untuk memastikan kelengkapan berkas dan pembayaran.",
   },
   {
-    date: "2024-07-25",
-    title: "Daftar Ulang",
+    date: "2025-07-22",
+    title: "Orientasi Orang Tua",
     description:
-      "Konfirmasi dan pembayaran biaya pendidikan untuk siswa yang diterima.",
+      "Pertemuan bersama wali kelas dan pengarahan sebelum tahun ajaran baru dimulai.",
   },
   {
-    date: "2024-07-29",
+    date: "2025-07-29",
     title: "Hari Pertama Sekolah",
-    description: "Awal dari petualangan belajar yang menyenangkan!",
+    description: "Tahun ajaran 2025/2026 resmi dimulai di TK Kartikasari.",
   },
 ];
 
@@ -223,7 +223,7 @@ export const fallbackContent: SiteContent = {
     faqs: ppdbFaqs,
     requirements: ppdbRequirements,
     timeline: fallbackPpdbTimeline,
-    deadline: "2024-07-15T23:59:59+07:00",
+    deadline: "2025-07-05T17:00:00+07:00",
   },
   biaya: {
     costStructure: mapCostStructure(),


### PR DESCRIPTION
## Summary
- update the PPDB page hero, notice, and CTAs to state that 2025/2026 in-person admissions have closed and direct families to the waitlist
- refresh the home onboarding guidance and PPDB fallback content so it references the closed intake, 2025 timeline, and updated requirement dates

## Testing
- `npm run lint` *(warnings: legacy <img> usage in fasilitas, galeri, header pages and anonymous default export in sanity schema)*

------
https://chatgpt.com/codex/tasks/task_e_68d95909f9ac832fb374963821103259