### PR TITLE
Improve header tagline and mobile nav timing

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -12,6 +12,7 @@ export default function Header() {
   const { siteSettings } = useSiteData();
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
+  const tagline = siteSettings.tagline?.trim() || 'PAUD hangat di Bantarsari, Cilacap.';
 
   const toggleMobileMenu = () => setMobileMenuOpen((prev) => !prev);
   const closeMobileMenu = () => setMobileMenuOpen(false);
@@ -57,8 +58,11 @@ export default function Header() {
               </span>
               <span className="flex min-w-0 flex-col leading-tight">
                 <span className="truncate text-base font-semibold md:text-lg">{siteSettings.schoolName}</span>
-                <span className="hidden text-xs text-text-muted sm:inline">
-                  {siteSettings.address}
+                <span
+                  className="hidden text-xs text-text-muted sm:block sm:text-sm"
+                  title={siteSettings.address}
+                >
+                  {tagline}
                 </span>
               </span>
             </Link>

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -21,23 +21,23 @@ const menuVariants: Variants = {
     opacity: 1,
     y: 0,
     transition: {
-      duration: 0.4,
+      duration: 0.55,
       ease: smoothEase,
       // Stagger the animation of children (nav items) when the menu enters
-      delayChildren: 0.1, // Start animating children after a brief delay
-      staggerChildren: 0.05, // Stagger each child's animation
+      delayChildren: 0.15, // Start animating children after a brief delay
+      staggerChildren: 0.08, // Stagger each child's animation
     },
   },
   exit: {
     opacity: 0,
     y: '-100%',
     transition: {
-      duration: 0.3,
+      duration: 0.45,
       ease: [0.4, 0, 1, 1] as const,
       // IMPORTANT: Wait for children to finish their exit animation before this one starts
       when: 'afterChildren',
       // Stagger the exit of children, in reverse order
-      staggerChildren: 0.04,
+      staggerChildren: 0.06,
       staggerDirection: -1,
     },
   },
@@ -53,7 +53,7 @@ const navItemVariants: Variants = {
     opacity: 1,
     y: 0,
     transition: {
-      duration: 0.35,
+      duration: 0.45,
       ease: smoothEase,
     },
   },
@@ -61,7 +61,7 @@ const navItemVariants: Variants = {
     opacity: 0,
     y: 20, // Move down on exit
     transition: {
-      duration: 0.2, // Items fade out quickly
+      duration: 0.3, // Items fade out smoothly
       ease: 'easeIn',
     },
   },
@@ -69,9 +69,9 @@ const navItemVariants: Variants = {
 
 // VARIANTS FOR THE ACCORDION CONTENT (SUB-MENU)
 const accordionContentVariants: Variants = {
-  hidden: { opacity: 0, height: 0, transition: { duration: 0.3, ease: smoothEase } },
-  visible: { opacity: 1, height: 'auto', transition: { duration: 0.4, ease: smoothEase } },
-  exit: { opacity: 0, height: 0, transition: { duration: 0.3, ease: smoothEase } },
+  hidden: { opacity: 0, height: 0, transition: { duration: 0.35, ease: smoothEase } },
+  visible: { opacity: 1, height: 'auto', transition: { duration: 0.45, ease: smoothEase } },
+  exit: { opacity: 0, height: 0, transition: { duration: 0.35, ease: smoothEase } },
 };
 
 interface MobileMenuProps {

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -22,12 +22,12 @@ export default function MobileNav({ isOpen, onToggle }: MobileNavProps) {
           <motion.span
             className="absolute left-0 top-1 h-0.5 w-full rounded bg-current"
             animate={isOpen ? { rotate: 45, y: 5 } : { rotate: 0, y: 0 }}
-            transition={{ duration: 0.2, ease: 'easeOut' }}
+            transition={{ duration: 0.32, ease: [0.4, 0, 0.2, 1] }}
           />
           <motion.span
             className="absolute left-0 bottom-1 h-0.5 w-full rounded bg-current"
             animate={isOpen ? { rotate: -45, y: -5 } : { rotate: 0, y: 0 }}
-            transition={{ duration: 0.2, ease: 'easeOut' }}
+            transition={{ duration: 0.32, ease: [0.4, 0, 0.2, 1] }}
           />
         </span>
       </motion.button>

--- a/data/site.json
+++ b/data/site.json
@@ -1,6 +1,7 @@
 {
   "schoolName": "TK Kartikasari",
   "siteUrl": "https://tkkartikasari.vercel.app",
+  "tagline": "Belajar hangat dan menyenangkan untuk anak usia dini di Bantarsari.",
   "address": "Jl. K.H. Syarbini Hasan No.2, Sidadadi, Bulaksari, Kec. Bantarsari, Kabupaten Cilacap, Jawa Tengah 53258",
   "whatsapp": "085227227826",
   "headmaster": "Ibu Mintarsih",

--- a/lib/fallback-content.ts
+++ b/lib/fallback-content.ts
@@ -60,6 +60,7 @@ function mapSiteSettings(): SiteSettings {
   return {
     schoolName: site.schoolName,
     siteUrl: site.siteUrl,
+    tagline: site.tagline ?? "PAUD hangat di Bantarsari, Cilacap.",
     address: site.address,
     whatsapp: site.whatsapp,
     headmaster: site.headmaster,

--- a/lib/sanity.queries.ts
+++ b/lib/sanity.queries.ts
@@ -8,6 +8,7 @@ const SITE_CONTENT_QUERY = `*[_type == "siteContent"][0]{
   "siteSettings": {
     "schoolName": siteSettings.schoolName,
     "siteUrl": siteSettings.siteUrl,
+    "tagline": siteSettings.tagline,
     "address": siteSettings.address,
     "whatsapp": siteSettings.whatsapp,
     "headmaster": siteSettings.headmaster,

--- a/lib/types/site.ts
+++ b/lib/types/site.ts
@@ -17,6 +17,7 @@ export type SocialLink = {
 export type SiteSettings = {
   schoolName: string;
   siteUrl: string;
+  tagline: string;
   address: string;
   whatsapp: string;
   headmaster: string;

--- a/sanity/schemas/siteContent.ts
+++ b/sanity/schemas/siteContent.ts
@@ -30,6 +30,13 @@ export const siteContent = defineType({
           validation: (rule) => rule.required(),
         }),
         defineField({
+          name: "tagline",
+          title: "Tagline",
+          type: "string",
+          description: "Singkatkan maksimal 80 karakter agar terbaca di header.",
+          validation: (rule) => rule.required().max(80),
+        }),
+        defineField({
           name: "address",
           title: "Alamat",
           type: "text",


### PR DESCRIPTION
## Summary
- use the site tagline in the header instead of the full address and expose the value via data, fallback, and schema updates
- slow down the mobile hamburger icon and menu animations for a smoother open/close experience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9602fd9f0832f897e33b55f5c4e21