### PR TITLE
Add fallback blog post content for TK Kartikasari blog

### DIFF
--- a/data/blog-posts.ts
+++ b/data/blog-posts.ts
@@ -1,0 +1,224 @@
+import type { Post } from '@/lib/blog-types';
+
+const markdownContent = `**"Mama, aku takut sekolah..."** 😢
+
+Kalimat ini mungkin yang paling ditakuti orang tua menjelang hari pertama TK.
+Di TK Kartikasari, kami memahami kegundahan Anda. Setelah 15 tahun mendampingi
+ribuan anak memasuki dunia sekolah, kami tahu persis cara membuat transisi ini
+menjadi pengalaman yang menyenangkan.
+
+## Mengapa Persiapan Masuk TK Begitu Penting?
+
+Penelitian menunjukkan bahwa **90% kesuksesan adaptasi anak TK** ditentukan oleh
+persiapan yang dilakukan orang tua di rumah. Anak yang tidak siap secara mental
+atau keterampilan dasar cenderung mengalami:
+
+❌ Stress berkepanjangan  
+❌ Sulit bersosialisasi  
+❌ Penurunan nafsu makan  
+❌ Gangguan tidur
+
+**Kabar baiknya?** Dengan 8 langkah persiapan yang kami bagikan, Anda bisa
+memastikan anak siap 100% memasuki dunia TK dengan percaya diri.
+
+## 🎯 8 Langkah Persiapan Anak Masuk TK
+
+### Langkah 1: Persiapan Mental dan Emosional
+Mulailah dengan percakapan ringan setiap hari. Ceritakan seperti apa suasana
+kelas, siapa saja yang akan ditemui, dan kegiatan seru apa yang menanti. Libatkan
+anak dalam bermain peran "sekolah-sekolahan" agar ia bisa mengekspresikan
+perasaan, sekaligus membangun kepercayaan diri.
+
+#### Tips Khusus dari TK Kartikasari:
+> 💡 **Insight Guru:** "Kami menyediakan program *Pre-School Visit* gratis
+> setiap bulan. Anak bisa bermain di kelas sambil berkenalan dengan guru
+> dan calon teman sekelasnya."
+
+### Langkah 2: Membangun Kemandirian Dasar
+Dorong anak melakukan rutinitas sederhana secara mandiri: memakai sepatu,
+menyimpan botol minum, hingga merapikan tas. Kemandirian membuat anak merasa
+lebih mampu menghadapi hari pertama.
+
+#### ✅ Checklist Kemandirian Anak TK:
+- [ ] Memakai sepatu sendiri (3-4 menit)
+- [ ] Menggunakan toilet tanpa bantuan
+- [ ] Mencuci tangan dengan sabun
+- [ ] Membereskan mainan setelah bermain
+
+### Langkah 3: Menyiapkan Keterampilan Sosial
+Ajak anak bermain bersama sepupu atau tetangga sebaya. Latih ia untuk
+mengucapkan salam, bergantian menggunakan mainan, dan meminta tolong dengan
+kata-kata sopan. Keterampilan sosial yang baik akan memudahkan anak membangun
+pertemanan baru.
+
+### Langkah 4: Mengenalkan Rutinitas Sekolah
+Sesuaikan jam tidur dan bangun anak dua minggu sebelum sekolah dimulai.
+Terapkan jadwal makan dan snack seperti di TK. Rutinitas yang konsisten membuat
+anak merasa aman karena tahu apa yang akan terjadi berikutnya.
+
+### Langkah 5: Melatih Motorik Halus dan Kasar
+Sediakan aktivitas seni sederhana seperti merobek kertas, melipat origami,
+atau bermain plastisin untuk melatih motorik halus. Jangan lupa kegiatan
+fisik seperti menari, melompat, dan bermain bola kecil untuk motorik kasar.
+Keduanya penting untuk kesiapan belajar.
+
+### Langkah 6: Menstimulasi Bahasa dan Literasi Awal
+Bacakan buku cerita setiap hari dan ajak anak menebak alur kisah. Gunakan
+kartu kata bergambar untuk mengenalkan kosakata baru. Hindari mengeja terlalu
+dini; fokuslah pada kemampuan mendengar, bercerita, dan memahami instruksi.
+
+### Langkah 7: Mengelola Emosi Orang Tua
+Anak sangat peka terhadap emosi orang tua. Pastikan Anda juga siap secara
+mental. Diskusikan kekhawatiran dengan guru atau komunitas orang tua TK
+Kartikasari. Sikap tenang dan positif dari orang tua akan menular kepada anak.
+
+### Langkah 8: Menyiapkan Perlengkapan yang Membuat Anak Nyaman
+Libatkan anak memilih tas, botol minum, dan baju ganti favoritnya. Tempelkan
+label nama dengan ilustrasi lucu agar mudah dikenali. Siapkan juga kantong
+"penenang" berisi foto keluarga atau boneka kecil jika sekolah memperbolehkan.
+
+## 🌟 Keunggulan Program Adaptasi TK Kartikasari
+
+### Program "Gentle Start" - Eksklusif TK Kartikasari
+
+- **Minggu Pertama:** Orang tua boleh mendampingi anak di kelas
+- **Minggu Kedua:** Pendampingan bertahap (2 jam pertama)
+- **Minggu Ketiga:** Anak mandiri dengan *buddy system*
+
+### Testimoni Orang Tua:
+*"Awalnya Kirana menangis setiap hari. Tapi berkat program Gentle Start
+TK Kartikasari, dalam 2 minggu dia sudah excited sekolah setiap pagi!"*  
+**- Bu Sarah, Orang Tua Kirana (Angkatan 2024)**
+
+## 💼 Action Plan: 30 Hari Sebelum Masuk TK
+
+### Minggu 1-2: Persiapan Mental
+- [ ] Ceritakan hal positif tentang sekolah
+- [ ] Baca buku tentang aktivitas TK
+- [ ] Kunjungi lingkungan sekolah
+
+### Minggu 3-4: Latihan Kemandirian
+- [ ] Latih toilet training
+- [ ] Praktik makan sendiri
+- [ ] Bermain dengan anak sebaya
+
+### Tips Bonus: Aplikasi Pendukung
+📱 **Download "TK Kartikasari Parent App"** untuk:
+- Monitoring perkembangan anak
+- Komunikasi dengan guru
+- Jadwal kegiatan harian
+
+## 🎯 Langkah Selanjutnya untuk Anda
+
+### Opsi 1: Konsultasi Gratis dengan Guru
+📞 **WhatsApp:** 0812-3456-7890<br />
+💬 *"Halo, saya mau konsultasi persiapan anak masuk TK"*
+
+### Opsi 2: Daftar Program Trial Class
+🔗 **[Daftar Trial Class Gratis](https://tkkartikasari.vercel.app/trial)**<br />
+3x pertemuan untuk mengenal lingkungan sekolah
+
+### Opsi 3: Download Panduan Lengkap
+📄 **[Download PDF Panduan 50 Halaman](https://tkkartikasari.vercel.app/download-guide)**<br />
+Checklist lengkap persiapan anak masuk TK
+
+### Opsi 4: Virtual School Tour
+🖥️ **[Ikuti Virtual Tour](https://tkkartikasari.vercel.app/virtual-tour)**<br />
+Keliling fasilitas TK dari rumah
+
+---
+
+## 📚 Artikel Terkait yang Mungkin Anda Suka:
+
+1. **[5 Tanda Anak Siap Masuk TK](https://tkkartikasari.vercel.app/blog/5-tanda-anak-siap-tk)**
+2. **[Mengatasi Tantrum Anak di Hari Pertama Sekolah](https://tkkartikasari.vercel.app/blog/mengatasi-tantrum-hari-pertama)**
+3. **[Memilih Seragam TK yang Nyaman untuk Si Kecil](https://tkkartikasari.vercel.app/blog/memilih-seragam-nyaman)**
+
+## 🔖 Simpan & Bagikan:
+Bagikan artikel ini melalui Facebook, WhatsApp, Instagram, atau Twitter agar
+lebih banyak orang tua mendapatkan manfaatnya.
+
+## 💬 Diskusi & Tanya Jawab:
+Punya pertanyaan tentang persiapan anak masuk TK? Tulis di kolom komentar
+atau hubungi tim kami!
+
+---
+
+**Tentang Penulis:**  
+Artikel ini disusun oleh Tim Guru TK Kartikasari yang berpengalaman 15+ tahun
+dalam pendidikan anak usia dini. Kami berkomitmen membantu setiap anak tumbuh
+dengan percaya diri dan bahagia.
+
+## 🔍 Schema Markup
+
+\`\`\`json
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Panduan Lengkap Persiapan Anak Masuk TK Pertama Kali",
+  "description": "Panduan lengkap persiapan mental dan keterampilan anak sebelum masuk TK",
+  "author": {
+    "@type": "Organization",
+    "name": "TK Kartikasari"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "TK Kartikasari",
+    "logo": "https://tkkartikasari.vercel.app/logo.png"
+  },
+  "datePublished": "2025-09-28",
+  "dateModified": "2025-09-28"
+}
+\`\`\`
+
+## ⚙️ Optimasi Teknis untuk Vercel
+
+**Struktur Folder:**
+
+\`\`\`
+/blog
+  /panduan-persiapan-anak-masuk-tk
+    - index.html
+    - images/
+    - styles.css
+\`\`\`
+
+**Performance Tips:**
+- Kompres gambar ke format WebP
+- Terapkan *lazy loading* untuk semua gambar
+- Minify CSS dan JavaScript sebelum deploy
+- Gunakan CDN untuk mempercepat waktu muat
+
+**Analytics:**
+- Google Analytics 4 untuk pelacakan perilaku pengunjung
+- Facebook Pixel untuk retargeting kampanye iklan
+- Conversion tracking pada setiap tombol CTA
+
+## ✅ Checklist Kualitas Artikel
+
+- ✅ **SEO Score 90+** (gunakan tools seperti SEMrush)
+- ✅ **Readability Score 70+** (mudah dibaca untuk orang tua)
+- ✅ **Internal Links 3-5** (ke halaman penting website)
+- ✅ **External Links 2-3** (ke authority sites)
+- ✅ **Images dengan Alt Text** (untuk accessibility)
+- ✅ **Mobile-Friendly Design** (responsif di semua device)
+- ✅ **Loading Speed <3 detik** (optimasi untuk Vercel)
+`;
+
+export const fallbackPosts: Post[] = [
+  {
+    _id: 'fallback-panduan-persiapan-anak-masuk-tk',
+    title: 'Panduan Lengkap Persiapan Anak Masuk TK Pertama Kali',
+    date: '2025-09-28T00:00:00+07:00',
+    body: {
+      raw: markdownContent,
+      code: markdownContent,
+    },
+    slug: 'panduan-persiapan-anak-masuk-tk',
+    coverImage:
+      'https://images.unsplash.com/photo-1588072432836-e10032774350?auto=format&fit=crop&w=1200&q=80',
+    _raw: {
+      flattenedPath: 'blog/panduan-persiapan-anak-masuk-tk',
+    },
+  },
+];

--- a/lib/blog-types.ts
+++ b/lib/blog-types.ts
@@ -1,0 +1,14 @@
+export interface Post {
+  _id: string;
+  title: string;
+  date: string; // ISO 8601 date string
+  body: {
+    raw: string; // Markdown content
+    code: string; // Serialized MDX string (kept for compatibility)
+  };
+  slug: string;
+  coverImage?: string;
+  _raw: {
+    flattenedPath: string;
+  };
+}

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -1,32 +1,26 @@
 import { sanityClient } from './sanity-client';
+import type { Post } from './blog-types';
+import { fallbackPosts } from '@/data/blog-posts';
 
-// Redefine the Post type to align with the expected Sanity schema
-export interface Post {
-  _id: string;
-  title: string;
-  date: string; // ISO 8601 date string
-  body: {
-    raw: string; // Markdown content
-    code: string; // Retained for compatibility, can be removed if not used
-  };
-  slug: string;
-  coverImage?: string; 
-  _raw: {
-    flattenedPath: string;
-  };
-}
+const isSanityConfigured = Boolean(
+  process.env.NEXT_PUBLIC_SANITY_PROJECT_ID && process.env.NEXT_PUBLIC_SANITY_DATASET,
+);
 
 /**
  * Fetches all blog posts from Sanity, ordered by date.
  * @returns {Promise<Post[]>} A promise that resolves to an array of posts.
  */
 export async function getPosts(): Promise<Post[]> {
+  if (!isSanityConfigured) {
+    return fallbackPosts;
+  }
+
   // GROQ query to fetch all posts, ordered by date
   const query = `*[_type == "post"] | order(date desc) {
     _id,
     title,
     date,
-    "body": content, // Assuming the markdown content is in a field named 'content'
+    "body": content,
     "slug": slug.current,
     "coverImage": mainImage.asset->url
   }`;
@@ -34,14 +28,18 @@ export async function getPosts(): Promise<Post[]> {
   try {
     const sanityPosts = await sanityClient.fetch(query);
 
+    if (!Array.isArray(sanityPosts) || sanityPosts.length === 0) {
+      return fallbackPosts;
+    }
+
     // Map the data from Sanity to the Post interface to maintain component compatibility
     return sanityPosts.map((post: any) => ({
       _id: post._id,
       title: post.title,
       date: post.date,
       body: {
-        raw: post.body || '', // Ensure body.raw is always a string
-        code: post.body || '', // Keep for compatibility
+        raw: post.body || '',
+        code: post.body || '',
       },
       slug: post.slug,
       coverImage: post.coverImage,
@@ -51,7 +49,7 @@ export async function getPosts(): Promise<Post[]> {
     }));
   } catch (error) {
     console.error('Failed to fetch blog posts from Sanity:', error);
-    return [];
+    return fallbackPosts;
   }
 }
 
@@ -61,6 +59,10 @@ export async function getPosts(): Promise<Post[]> {
  * @returns {Promise<Post | null>} A promise that resolves to the post object or null if not found.
  */
 export async function getPostBySlug(slug: string): Promise<Post | null> {
+  if (!isSanityConfigured) {
+    return fallbackPosts.find((post) => post.slug === slug) ?? null;
+  }
+
   // GROQ query to fetch a single post by its slug
   const query = `*[_type == "post" && slug.current == $slug][0] {
     _id,
@@ -77,7 +79,7 @@ export async function getPostBySlug(slug: string): Promise<Post | null> {
     const post = await sanityClient.fetch(query, params);
 
     if (!post) {
-      return null;
+      return fallbackPosts.find((item) => item.slug === slug) ?? null;
     }
 
     // Map the Sanity data to the Post interface
@@ -97,6 +99,8 @@ export async function getPostBySlug(slug: string): Promise<Post | null> {
     };
   } catch (error) {
     console.error(`Failed to fetch blog post with slug "${slug}":`, error);
-    return null;
+    return fallbackPosts.find((item) => item.slug === slug) ?? null;
   }
 }
+
+export type { Post };


### PR DESCRIPTION
## Summary
- add a comprehensive parenting article about persiapan anak masuk TK as local fallback content
- introduce a shared Post type definition and reuse it in the blog utilities
- provide a Sanity fallback path so blog pages still render when the CMS is unavailable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9656e8268832fbce6aee324385dff