### PR TITLE
Enable ISR for blog pages

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,11 +1,13 @@
 import { notFound } from 'next/navigation';
 import Image from 'next/image';
 import { getPosts, getPostBySlug } from '@/lib/blog'; // Import Post from @/lib/blog
-import { Calendar, Clock, Person } from 'react-bootstrap-icons';
+import { Clock, Person } from 'react-bootstrap-icons';
 import Mdx from '@/components/mdx/Mdx';
 import EngagementSection from '@/components/blog/EngagementSection';
 import { createPageMetadata } from "@/lib/metadata";
 import { calculateReadingTime } from '@/lib/utils';
+
+export const revalidate = 60; // refresh detail pages regularly for new/updated posts
 
 
 // Generate static paths for all blog posts

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -5,6 +5,8 @@ import PageHeader from '@/components/layout/PageHeader';
 import { getPosts, Post } from '@/lib/blog'; // Import Post from @/lib/blog
 import { ArrowRight } from 'react-bootstrap-icons';
 
+export const revalidate = 60; // revalidate list every minute to pick up new posts
+
 export default async function BlogListPage() {
   const posts = await getPosts();
 


### PR DESCRIPTION
## Summary
- enable incremental static regeneration for the blog index and detail pages
- remove an unused Calendar icon import from the blog detail page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da08b1c03c832fa56f3d6d2e289d9b