### PR TITLE
Improve Tentang Kami page copy and teacher highlights

### DIFF
--- a/components/tentang/AboutPageContent.tsx
+++ b/components/tentang/AboutPageContent.tsx
@@ -1,6 +1,7 @@
 
 'use client';
 import React from "react";
+import Link from "next/link";
 import CTAButton from "@/components/CTAButton";
 import PageHeader from "@/components/layout/PageHeader";
 import PageSection from "@/components/layout/PageSection";
@@ -99,9 +100,18 @@ export default function AboutPageContent({
               <People className="mx-auto h-10 w-10 text-secondary" />
               <h3 className="text-xl font-semibold">Kemitraan dengan Keluarga</h3>
               <p className="text-sm text-text-muted">
-                Kolaborasi aktif dengan orang tua melalui asesmen autentik untuk pembelajaran yang saling menguatkan.
+                Kolaborasi aktif dengan orang tua melalui komunikasi rutin dan refleksi perkembangan agar belajar saling
+                menguatkan.
               </p>
             </AnimateIn>
+          </div>
+          <div className="flex justify-center">
+            <Link
+              href="/program"
+              className="inline-flex items-center gap-2 rounded-full bg-white/70 px-6 py-3 text-sm font-semibold text-secondary shadow-soft transition hover:bg-white"
+            >
+              Lihat Lebih Lanjut: Bagaimana Kami Mengajar Anak Anda? Lihat Rincian Program Kami Selengkapnya →
+            </Link>
           </div>
         </AnimateIn>
       </PageSection>
@@ -137,10 +147,10 @@ export default function AboutPageContent({
           className="grid items-start gap-12 lg:grid-cols-[0.9fr,1.1fr]"
         >
           <div className="space-y-6 lg:sticky lg:top-24">
-            <h2 className="text-3xl font-semibold text-text">Profil Resmi Sekolah</h2>
+            <h2 className="text-3xl font-semibold text-text">Jaminan Kredibilitas & Legalitas Sekolah</h2>
             <p className="text-base leading-relaxed text-text-muted">
-              Transparansi adalah fondasi kepercayaan. Berikut adalah data resmi TK Kartikasari yang terdaftar di
-              Kemendikbudristek, menegaskan komitmen dan legalitas kami dalam melayani keluarga Bantarsari.
+              Transparansi adalah fondasi kepercayaan. Berikut data resmi TK Kartikasari yang menegaskan komitmen kami
+              dalam melayani keluarga Bantarsari dengan amanah dan akuntabel.
             </p>
             <div className="flex flex-wrap gap-3">
               <CTAButton ctaKey="ppdbHeadmaster" />
@@ -152,6 +162,10 @@ export default function AboutPageContent({
               className="card h-full space-y-5 bg-white/60 p-7 shadow-soft backdrop-blur-xl"
             >
               <h3 className="text-xl font-semibold text-text">Identitas & Legalitas</h3>
+              <p className="text-sm font-medium text-secondary">
+                Kami adalah lembaga pendidikan yang terdaftar dan diakui secara resmi oleh Kemendikbudristek sejak tahun
+                1998.
+              </p>
               <ul className="grid gap-4 sm:grid-cols-2">
                 {[
                   { label: "Nama Sekolah", value: siteSettings.schoolName, icon: Mortarboard },
@@ -214,10 +228,11 @@ export default function AboutPageContent({
         >
           <div className="space-y-3">
             <h2 className="text-balance text-3xl font-semibold text-text">
-              Pendidik Profesional & Penyayang
+              Tim Pendidik Kami: Berkomitmen, Berkompeten, dan Penuh Kasih.
             </h2>
             <p className="mx-auto max-w-3xl text-base leading-relaxed text-text-muted">
-              Di TK Kartikasari, kami percaya bahwa guru adalah jantung dari pendidikan. Tim kami terdiri dari para pendidik yang berdedikasi, penuh kasih, dan berkompeten di bidangnya.
+              Di TK Kartikasari, guru adalah sahabat belajar pertama bagi anak. Mereka hadir mendampingi emosi, imajinasi,
+              dan rasa ingin tahu agar setiap hari sekolah terasa hangat dan bermakna.
             </p>
           </div>
           <TeacherList teachers={teachers} />

--- a/components/tentang/TeacherList.tsx
+++ b/components/tentang/TeacherList.tsx
@@ -49,6 +49,11 @@ export default function TeacherList({ teachers }: TeacherListProps) {
           <h3 className="text-2xl font-semibold text-text">{headmaster.name}</h3>
           <p className="text-base text-secondary">{headmaster.position}</p>
           <p className="mt-2 text-base text-text-muted">{headmaster.description}</p>
+          {headmaster.impactStatement ? (
+            <p className="mt-3 text-sm font-semibold text-secondary/80">
+              {headmaster.impactStatement}
+            </p>
+          ) : null}
         </m.div>
       )}
 
@@ -68,6 +73,9 @@ export default function TeacherList({ teachers }: TeacherListProps) {
             <h3 className="text-xl font-semibold text-text">{teacher.name}</h3>
             <p className="text-sm text-secondary">{teacher.position}</p>
             <p className="mt-2 text-sm text-text-muted">{teacher.description}</p>
+            {teacher.impactStatement ? (
+              <p className="mt-3 text-sm font-semibold text-secondary/80">{teacher.impactStatement}</p>
+            ) : null}
           </m.div>
         ))}
       </m.div>

--- a/content/about.ts
+++ b/content/about.ts
@@ -80,9 +80,9 @@ export const aboutStrengths: StrengthItem[] = [
 ];
 
 export const aboutMission: string[] = [
-  "Menguatkan karakter religius, empati, dan kemandirian melalui pembiasaan harian yang positif.",
-  "Menghadirkan pengalaman Kurikulum Merdeka yang menyenangkan, terdiferensiasi, dan relevan dengan kehidupan anak.",
-  "Membangun kemitraan erat bersama keluarga untuk menyukseskan Projek Profil Pelajar Pancasila dan asesmen autentik.",
-  "Menyediakan lingkungan belajar yang aman, inklusif, dan kaya akan stimulasi positif.",
-  "Mengembangkan literasi, numerasi, serta kecakapan saintifik, teknologi, dan seni sebagai bekal transisi menuju sekolah dasar.",
+  "Menumbuhkan karakter religius, empati, dan kemandirian melalui rutinitas harian yang hangat.",
+  "Menghadirkan kegiatan belajar yang menyenangkan, mudah dipahami, dan sesuai usia anak.",
+  "Membangun kemitraan erat dengan keluarga untuk memastikan pembelajaran anak relevan dan saling mendukung.",
+  "Menjaga lingkungan bermain yang aman, inklusif, dan kaya stimulasi positif.",
+  "Mendorong anak bereksplorasi lewat literasi, numerasi, seni, dan teknologi secara bertahap.",
 ];

--- a/content/teachers.ts
+++ b/content/teachers.ts
@@ -4,24 +4,36 @@ export const teachers = [
     name: "Bu Mintarsih",
     position: "Kepala Sekolah",
     imageUrl: "/images/teachers/teacher-1.jpg",
-    description: "Berdedikasi memastikan setiap aspek pendidikan selaras dengan visi sekolah. Beliau menciptakan lingkungan belajar yang aman, berkarakter, dan mendukung pertumbuhan individual setiap anak."
+    description:
+      "Berdedikasi memastikan setiap aspek pendidikan selaras dengan visi sekolah. Beliau menciptakan lingkungan belajar yang aman, berkarakter, dan mendukung pertumbuhan individual setiap anak.",
+    impactStatement:
+      "Prinsip: Setiap anak adalah individu unik yang berhak mendapat awal terbaik, itulah janji TK Kartikasari.",
   },
   {
     name: "Ibu Guru A",
     position: "Guru Kelas A",
     imageUrl: "/images/teachers/teacher-2.jpg",
-    description: "Ahli merancang kegiatan berbasis permainan dan eksplorasi kreatif. Beliau mengubah rasa ingin tahu anak menjadi pengetahuan, membuat proses belajar selalu aktif dan penuh semangat."
+    description:
+      "Ahli merancang kegiatan berbasis permainan dan eksplorasi kreatif. Beliau mengubah rasa ingin tahu anak menjadi pengetahuan, membuat proses belajar selalu aktif dan penuh semangat.",
+    impactStatement:
+      "Ia memastikan setiap anak merasa didengar sehingga keberanian mencoba hal baru tumbuh dari hari ke hari.",
   },
   {
     name: "Ibu Guru B",
     position: "Guru Kelas B",
     imageUrl: "/images/teachers/teacher-3.jpg",
-    description: "Fokus pada pengembangan keterampilan sosial-emosional dan kemandirian. Dengan pendekatan yang sabar, beliau membantu anak membangun rasa percaya diri dan kemampuan berinteraksi."
+    description:
+      "Fokus pada pengembangan keterampilan sosial-emosional dan kemandirian. Dengan pendekatan yang sabar, beliau membantu anak membangun rasa percaya diri dan kemampuan berinteraksi.",
+    impactStatement:
+      "Kehangatannya membuat anak berani mengungkapkan perasaan dan bangga atas setiap kemajuan kecil.",
   },
   {
     name: "Bapak Guru C",
     position: "Guru Olahraga",
     imageUrl: "/images/teachers/teacher-4.jpg",
-    description: "Mengenalkan gaya hidup sehat melalui aktivitas fisik yang terstruktur dan aman. Beliau menanamkan nilai sportivitas dan kerja sama tim sejak dini melalui permainan yang menyenangkan."
+    description:
+      "Mengenalkan gaya hidup sehat melalui aktivitas fisik yang terstruktur dan aman. Beliau menanamkan nilai sportivitas dan kerja sama tim sejak dini melalui permainan yang menyenangkan.",
+    impactStatement:
+      "Energinya menularkan rasa gembira sehingga anak memahami arti sportif dan saling menyemangati teman.",
   },
 ];

--- a/data/cta.ts
+++ b/data/cta.ts
@@ -18,7 +18,7 @@ export const generalInquiryCTA: CTAConfig = {
 };
 
 export const heroVisitCTA: CTAConfig = {
-  label: "Daftar PPDB & Tur Sekolah",
+  label: "Daftar PPDB & Jadwalkan Tur Sekolah Hari Ini",
   message:
     "Halo Bu Mintarsih, saya ingin menjadwalkan kunjungan dan mendapatkan info PPDB TK Kartikasari.",
   variant: "primary",

--- a/lib/fallback-content.ts
+++ b/lib/fallback-content.ts
@@ -214,6 +214,7 @@ export const fallbackContent: SiteContent = {
     position: teacher.position,
     description: teacher.description,
     imageUrl: teacher.imageUrl,
+    impactStatement: teacher.impactStatement,
   })),
   program: {
     classes: programClasses,

--- a/lib/sanity.queries.ts
+++ b/lib/sanity.queries.ts
@@ -40,7 +40,7 @@ const SITE_CONTENT_QUERY = `*[_type == "siteContent"][0]{
     "officialProfile": aboutPage.officialProfile,
     "milestones": aboutPage.milestones[]{ year, title, description }
   },
-  "teachers": teachers[]{ name, position, description, "imageUrl": image.asset->url },
+  "teachers": teachers[]{ name, position, description, impactStatement, "imageUrl": image.asset->url },
   "program": {
     "classes": programPage.classes[]{ name, age, description, focus },
     "learningMethods": programPage.learningMethods[]{ title, description },

--- a/lib/types/site.ts
+++ b/lib/types/site.ts
@@ -76,6 +76,7 @@ export type TeacherProfile = {
   position: string;
   description: string;
   imageUrl?: string | null;
+  impactStatement?: string | null;
 };
 
 export type ProgramClass = {

--- a/sanity/schemas/siteContent.ts
+++ b/sanity/schemas/siteContent.ts
@@ -408,6 +408,7 @@ export const siteContent = defineType({
             defineField({ name: "name", title: "Nama", type: "string", validation: (rule) => rule.required() }),
             defineField({ name: "position", title: "Jabatan", type: "string", validation: (rule) => rule.required() }),
             defineField({ name: "description", title: "Deskripsi", type: "text", rows: 3 }),
+            defineField({ name: "impactStatement", title: "Pernyataan Dampak", type: "text", rows: 2 }),
             defineField({ name: "image", title: "Foto", type: "image", options: { hotspot: true } }),
           ],
         }),


### PR DESCRIPTION
## Summary
- refresh the Tentang Kami page microcopy with a program CTA, clearer legal assurances, and warmer teacher section messaging
- simplify the mission statements and add personalized impact statements for each teacher
- extend the CTA label, fallback content, and Sanity schema/types to support the new copy updates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da27668b74832fa677f80ee29cd86c