### PR TITLE
Strip HTML tags from blog previews

### DIFF
--- a/components/home/HomePageContent.tsx
+++ b/components/home/HomePageContent.tsx
@@ -488,6 +488,7 @@ export default function HomePageContent({
                   const normalizedBody = rawBody
                     .replace(/[#*_`>\-]/g, '')
                     .replace(/\[(.*?)\]\(.*?\)/g, '$1')
+                    .replace(/<[^>]+>/g, ' ')
                     .replace(/\s+/g, ' ')
                     .trim();
                   const description =


### PR DESCRIPTION
## Summary
- strip HTML tags from blog post bodies before generating preview text
- ensure normalized blog preview text remains trimmed and limited to 160 characters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbe980ea64832fafd6581ef7efe010