### PR TITLE
Fix focus-visible styling for onboarding and blog links

### DIFF
--- a/components/home/HomePageContent.tsx
+++ b/components/home/HomePageContent.tsx
@@ -199,7 +199,7 @@ export default function HomePageContent({
               >
                 <Link
                   href={step.href}
-                  className="focus-visible-ring group flex h-full flex-col justify-between rounded-3xl border border-white/60 bg-white/70 p-7 text-left shadow-soft backdrop-blur-xl backdrop-saturate-150 transition-all duration-300 hover:-translate-y-1 hover:border-primary/60"
+                  className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 group flex h-full flex-col justify-between rounded-3xl border border-white/60 bg-white/70 p-7 text-left shadow-soft backdrop-blur-xl backdrop-saturate-150 transition-all duration-300 hover:-translate-y-1 hover:border-primary/60"
                 >
                   <div>
                     <span className="inline-flex items-center gap-3 rounded-full bg-primary/10 px-4 py-2 text-sm font-semibold text-primary">
@@ -494,7 +494,11 @@ export default function HomePageContent({
                     normalizedBody.length > 160 ? `${normalizedBody.slice(0, 157)}...` : normalizedBody;
 
                   return (
-                    <Link href={`/blog/${post.slug}`} key={post.slug} className="focus-visible-ring group block rounded-2xl">
+                    <Link
+                      href={`/blog/${post.slug}`}
+                      key={post.slug}
+                      className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 group block rounded-2xl"
+                    >
                       <article className="card h-full transform-gpu bg-white/60 shadow-soft backdrop-blur-xl transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-primary/20">
                         <div className="relative aspect-[16/9] w-full overflow-hidden rounded-t-2xl">
                           {coverImage ? (


### PR DESCRIPTION
## Summary
- replace the deprecated `focus-visible-ring` utility on onboarding cards with Tailwind focus ring classes
- apply the same accessible focus styling to blog post link wrappers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbe99c2990832f8d47eac502751cbd