### PR TITLE
Update site tagline copy

### DIFF
--- a/data/site.json
+++ b/data/site.json
@@ -1,7 +1,7 @@
 {
   "schoolName": "TK Kartikasari",
   "siteUrl": "https://tkkartikasari.vercel.app",
-  "tagline": "Belajar hangat dan menyenangkan untuk anak usia dini di Bantarsari.",
+  "tagline": "Belajar hangat & ceria di Bantarsari.",
   "address": "Jl. K.H. Syarbini Hasan No.2, Sidadadi, Bulaksari, Kec. Bantarsari, Kabupaten Cilacap, Jawa Tengah 53258",
   "whatsapp": "085227227826",
   "headmaster": "Ibu Mintarsih",

--- a/lib/fallback-content.ts
+++ b/lib/fallback-content.ts
@@ -60,7 +60,7 @@ function mapSiteSettings(): SiteSettings {
   return {
     schoolName: site.schoolName,
     siteUrl: site.siteUrl,
-    tagline: site.tagline ?? "PAUD hangat di Bantarsari, Cilacap.",
+    tagline: site.tagline ?? "Belajar hangat & ceria di Bantarsari.",
     address: site.address,
     whatsapp: site.whatsapp,
     headmaster: site.headmaster,


### PR DESCRIPTION
## Summary
- shorten the site tagline copy for the header
- align the fallback tagline string with the new copy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbea971dbc832fa156bb82310c45c5