### PR TITLE
Enhance home experience with Reactbits-inspired patterns

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -51,6 +51,24 @@ body {
   @apply rounded-xl border border-border/70 bg-surface shadow-soft backdrop-blur;
 }
 
+@keyframes marquee-slow {
+  0% {
+    transform: translateX(0%);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
+}
+
+.animate-marquee {
+  animation: marquee-slow var(--marquee-duration, 36s) linear infinite;
+  will-change: transform;
+}
+
+.animate-marquee[data-paused="true"] {
+  animation-play-state: paused;
+}
+
 /* UPDATED: Changed focus ring to match new orange theme accent */
 .input {
   @apply w-full rounded-xl border border-border/70 bg-white px-4 py-3 text-base text-text placeholder:text-text-muted transition focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-400/40;

--- a/components/TestimonialList.tsx
+++ b/components/TestimonialList.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo, useState, type CSSProperties } from "react";
 import { LazyMotion, domAnimation, m } from "framer-motion";
 
 import PageSection from "@/components/layout/PageSection";
@@ -11,7 +12,22 @@ interface TestimonialListProps {
 }
 
 export default function TestimonialList({ testimonials }: TestimonialListProps) {
-  if (!testimonials || testimonials.length === 0) {
+  const safeTestimonials = useMemo(
+    () => (testimonials?.length ? testimonials : []),
+    [testimonials],
+  );
+  const duplicatedTestimonials = useMemo(
+    () => [...safeTestimonials, ...safeTestimonials],
+    [safeTestimonials],
+  );
+  const [isPaused, setIsPaused] = useState(false);
+  const marqueeDurationSeconds = Math.max(28, safeTestimonials.length * 7 || 0);
+  const marqueeStyle = useMemo(
+    () => ({ "--marquee-duration": `${marqueeDurationSeconds}s` }) as CSSProperties,
+    [marqueeDurationSeconds],
+  );
+
+  if (safeTestimonials.length === 0) {
     return (
       <PageSection id="testimonials" padding="relaxed">
         <div className="card mx-auto max-w-3xl border border-border/70 bg-secondary/5 p-8 text-center text-text-muted">
@@ -56,28 +72,32 @@ export default function TestimonialList({ testimonials }: TestimonialListProps) 
             />
           </m.div>
 
-          <div className="mt-14 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {testimonials.map((t, index) => (
-              <m.blockquote
-                key={t.id}
-                initial={{ opacity: 0, y: 40 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true, amount: 0.3 }}
-                transition={{ duration: 0.55, delay: index * 0.08 }}
-                className="card relative overflow-hidden p-7 text-left"
-              >
-                <div className="absolute inset-0 bg-gradient-to-br from-primary/6 via-white to-secondary/10" />
-                <div className="relative flex flex-col gap-4">
-                  <div className="flex items-center gap-2 text-lg text-accent">
-                    {Array.from({ length: t.rating ?? 5 }).map((_, starIndex) => (
-                      <span key={starIndex}>★</span>
-                    ))}
+          <div className="mt-14 overflow-hidden">
+            <div
+              className="flex w-max gap-6 animate-marquee"
+              style={marqueeStyle}
+              data-paused={isPaused ? "true" : "false"}
+              onMouseEnter={() => setIsPaused(true)}
+              onMouseLeave={() => setIsPaused(false)}
+            >
+              {duplicatedTestimonials.map((t, index) => (
+                <blockquote
+                  key={`${t.id}-${index}`}
+                  className="card relative w-[min(320px,80vw)] shrink-0 overflow-hidden p-7 text-left"
+                >
+                  <div className="absolute inset-0 bg-gradient-to-br from-primary/6 via-white to-secondary/10" />
+                  <div className="relative flex h-full flex-col gap-4">
+                    <div className="flex items-center gap-2 text-lg text-accent">
+                      {Array.from({ length: t.rating ?? 5 }).map((_, starIndex) => (
+                        <span key={starIndex}>★</span>
+                      ))}
+                    </div>
+                    <p className="text-lg font-medium leading-relaxed text-text">“{t.quote}”</p>
+                    <p className="text-base font-semibold text-text/80">{t.author}</p>
                   </div>
-                  <p className="text-lg font-medium leading-relaxed text-text">“{t.quote}”</p>
-                  <p className="text-base font-semibold text-text/80">{t.author}</p>
-                </div>
-              </m.blockquote>
-            ))}
+                </blockquote>
+              ))}
+            </div>
           </div>
         </div>
       </PageSection>

--- a/components/home/HomePageContent.tsx
+++ b/components/home/HomePageContent.tsx
@@ -27,6 +27,10 @@ import {
   ppdbMetaDescription,
   syaratDanKetentuan as ppdbRequirementsStatic,
 } from "@/content/ppdb";
+import { AuroraBackground } from "@/components/reactbits/AuroraBackground";
+import AnimatedCounter from "@/components/reactbits/AnimatedCounter";
+import TimelineSteps from "@/components/reactbits/TimelineSteps";
+import StickyScrollReveal from "@/components/reactbits/StickyScrollReveal";
 
 type HomePageContentProps = {
   schoolName: string;
@@ -113,19 +117,14 @@ export default function HomePageContent({
   return (
       <main>
         {/* Section 1: Hero (Kail) */}
-        <PageSection
-          className="relative overflow-hidden"
-          padding="none"
-          containerClassName="relative grid gap-16 pb-24 pt-20 lg:grid-cols-[1.1fr,0.9fr] lg:items-center"
-        >
-          <div className="pointer-events-none absolute inset-0" aria-hidden="true">
-            <div className="absolute -top-32 right-16 h-72 w-72 rounded-full bg-secondary/20 blur-3xl" />
-            <div className="absolute -left-32 top-24 h-80 w-80 rounded-full bg-primary/25 blur-3xl" />
-            <div className="absolute inset-x-0 bottom-0 h-1/2 bg-hero-gradient" />
-          </div>
-          <div
-            className="relative space-y-8"
+        <AuroraBackground className="rounded-b-[2.5rem] border-b border-white/60 bg-gradient-to-br from-white via-secondary/10 to-primary/10">
+          <PageSection
+            padding="none"
+            containerClassName="relative grid gap-16 pb-24 pt-20 lg:grid-cols-[1.1fr,0.9fr] lg:items-center"
           >
+            <div
+              className="relative space-y-8"
+            >
             <span className="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/60 px-4 py-2 text-sm font-semibold text-secondary shadow-soft backdrop-blur-sm backdrop-saturate-150">
               <span className="h-2.5 w-2.5 rounded-full bg-secondary" aria-hidden="true" />
               {schoolName} • Kurikulum Merdeka PAUD
@@ -148,30 +147,33 @@ export default function HomePageContent({
                   key={item.label}
                   className="rounded-3xl border border-white/60 bg-white/60 p-5 text-left shadow-soft backdrop-blur-lg backdrop-saturate-150"
                 >
-                  <p className="text-3xl font-bold text-text">{item.value}</p>
+                  <p className="text-3xl font-bold text-text">
+                    <AnimatedCounter value={item.value} />
+                  </p>
                   <p className="mt-1 text-base text-text-muted">{item.label}</p>
                 </div>
               ))}
             </div>
-          </div>
-
-          <AnimateIn className="relative flex justify-center">
-            <div className="absolute -top-12 right-6 h-40 w-40 rounded-full bg-accent/30 blur-2xl" aria-hidden="true" />
-            <div className="absolute -bottom-6 left-2 h-36 w-36 rounded-full bg-secondary/25 blur-2xl md:-bottom-10" aria-hidden="true" />
-            <div className="relative w-full max-w-md space-y-5 rounded-[2.5rem] border border-white/60 bg-white/70 p-8 text-center shadow-soft backdrop-blur-xl backdrop-saturate-150">
-              <p className="text-lg font-semibold text-secondary">Belajar aktif & penuh perhatian</p>
-              <p className="text-base leading-relaxed text-text-muted">
-                Kelas kecil dengan guru pendamping personal membantu anak cepat nyaman, bereksplorasi, dan siap melanjutkan ke jenjang berikutnya.
-              </p>
-              <div className="flex items-center justify-center gap-3 text-base font-semibold text-text">
-                <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/15 text-lg" aria-hidden="true">
-                  😊
-                </span>
-                Rasio guru : anak {teacherStudentRatio}
-              </div>
             </div>
-          </AnimateIn>
-        </PageSection>
+
+            <AnimateIn className="relative flex justify-center">
+              <div className="absolute -top-12 right-6 h-40 w-40 rounded-full bg-accent/30 blur-2xl" aria-hidden="true" />
+              <div className="absolute -bottom-6 left-2 h-36 w-36 rounded-full bg-secondary/25 blur-2xl md:-bottom-10" aria-hidden="true" />
+              <div className="relative w-full max-w-md space-y-5 rounded-[2.5rem] border border-white/60 bg-white/70 p-8 text-center shadow-soft backdrop-blur-xl backdrop-saturate-150">
+                <p className="text-lg font-semibold text-secondary">Belajar aktif & penuh perhatian</p>
+                <p className="text-base leading-relaxed text-text-muted">
+                  Kelas kecil dengan guru pendamping personal membantu anak cepat nyaman, bereksplorasi, dan siap melanjutkan ke jenjang berikutnya.
+                </p>
+                <div className="flex items-center justify-center gap-3 text-base font-semibold text-text">
+                  <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/15 text-lg" aria-hidden="true">
+                    😊
+                  </span>
+                  Rasio guru : anak {teacherStudentRatio}
+                </div>
+              </div>
+            </AnimateIn>
+          </PageSection>
+        </AuroraBackground>
 
         {/* Section 2: Langkah Onboarding */}
         <PageSection
@@ -191,40 +193,7 @@ export default function HomePageContent({
               description="Gunakan empat langkah ini sebagai panduan mengenal sekolah dan menyiapkan dokumen sebelum periode pendaftaran tatap muka berikutnya dibuka."
             />
           </AnimateIn>
-          <div className="relative mt-12 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
-            {onboardingSteps.map((step, index) => (
-              <AnimateIn
-                key={step.key}
-                className="h-full"
-              >
-                <Link
-                  href={step.href}
-                  className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 group flex h-full flex-col justify-between rounded-3xl border border-white/60 bg-white/70 p-7 text-left shadow-soft backdrop-blur-xl backdrop-saturate-150 transition-all duration-300 hover:-translate-y-1 hover:border-primary/60"
-                >
-                  <div>
-                    <span className="inline-flex items-center gap-3 rounded-full bg-primary/10 px-4 py-2 text-sm font-semibold text-primary">
-                      <span className="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-primary/15 text-base" aria-hidden="true">
-                        {index + 1}
-                      </span>
-                      Langkah {index + 1}
-                    </span>
-                    <div className="mt-6 flex items-start gap-3">
-                      <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-2xl" aria-hidden="true">
-                        {step.icon}
-                      </span>
-                      <div>
-                        <h3 className="text-lg font-semibold text-text">{step.title}</h3>
-                        <p className="mt-3 text-sm leading-relaxed text-text-muted">{step.description}</p>
-                      </div>
-                    </div>
-                  </div>
-                  <span className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-primary transition-transform group-hover:translate-x-1">
-                    {step.linkLabel} <ArrowRight className="h-4 w-4" />
-                  </span>
-                </Link>
-              </AnimateIn>
-            ))}
-          </div>
+          <TimelineSteps steps={onboardingSteps} className="relative mt-12" />
           <div className="relative mt-12 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-center">
             <Link href="/ppdb" className="btn-primary w-full sm:w-auto">
               Info PPDB 2025/2026
@@ -353,14 +322,8 @@ export default function HomePageContent({
         </PageSection>
 
         {/* Section 5: Program & Aktivitas Harian (Eksekusi) */}
-        <PageSection
-          id="program"
-          padding="tight"
-          containerClassName="grid gap-12 lg:grid-cols-[1fr,1fr] lg:items-start"
-        >
-          <AnimateIn
-            className="space-y-6"
-          >
+        <PageSection id="program" padding="tight">
+          <AnimateIn className="max-w-3xl space-y-6">
             <SectionHeader
               eyebrow="Program Kurikulum Merdeka"
               eyebrowVariant="secondary"
@@ -388,37 +351,20 @@ export default function HomePageContent({
               </li>
             </ul>
           </AnimateIn>
-          <div className="grid gap-6">
-            {programs.map((program) => (
-              <AnimateIn
-                key={program.name}
-                className="card h-full border-white/70 bg-white/70 p-7 shadow-soft backdrop-blur-xl backdrop-saturate-150"
-              >
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                  <div className="space-y-3">
-                    <p className="text-sm font-semibold uppercase tracking-wide text-secondary">
-                      {program.age}
-                    </p>
-                    <h3 className="text-2xl font-semibold text-text">{program.name}</h3>
-                    <p className="text-base leading-relaxed text-text-muted">
-                      {program.description}
-                    </p>
-                  </div>
-                  <span className="inline-flex h-12 min-w-[3rem] items-center justify-center rounded-2xl bg-primary/15 text-2xl" aria-hidden="true">
-                    ✨
-                  </span>
-                </div>
-                <ul className="mt-6 space-y-2 text-base text-text-muted">
-                  {program.points.map((point) => (
-                    <li key={point} className="flex items-start gap-3">
-                      <CheckCircle className="mt-1 h-5 w-5 flex-shrink-0 text-secondary" aria-hidden="true" />
-                      {point}
-                    </li>
-                  ))}
-                </ul>
-              </AnimateIn>
-            ))}
-          </div>
+          <StickyScrollReveal
+            eyebrow="Sorot Program"
+            heading="Pengalaman belajar yang menyatu dari playgroup hingga TK B"
+            description="Setiap kelas dirancang dengan ritme yang lembut, memadukan eksplorasi terstruktur dan bermain bebas supaya anak belajar tanpa kehilangan rasa aman."
+            items={programs.map((program, index) => ({
+              id: `${program.name}-${index}`,
+              title: program.name,
+              subtitle: program.age,
+              description: program.description,
+              highlights: program.points,
+              icon: "✨",
+            }))}
+            className="mt-12"
+          />
         </PageSection>
 
         <PageSection
@@ -580,27 +526,27 @@ export default function HomePageContent({
 
         {/* Section 9: CTA Final - REVISED */}
         <PageSection className="relative pb-36" padding="tight">
-          <AnimateIn
-            className="card flex flex-col gap-6 overflow-hidden border-white/70 bg-gradient-to-br from-secondary/10 via-white to-primary/10 p-10 text-center md:flex-row md:items-center md:justify-between md:text-left"
-          >
-            <div className="max-w-xl space-y-4">
-              <span className="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/60 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-secondary backdrop-blur-sm backdrop-saturate-150">
-                Siap Bergabung
-              </span>
-              <h2 className="text-balance text-3xl font-semibold text-text sm:text-4xl">
-                Lihat Langsung Bagaimana Anak-Anak Belajar dengan Gembira
-              </h2>
-              <p className="text-base leading-relaxed text-text-muted">
-                Kami mengundang Anda untuk merasakan sendiri suasana hangat di kelas kami. Lihat sentra belajar yang interaktif dan temukan bagaimana projek seru kami menumbuhkan kreativitas serta rasa percaya diri anak.
-              </p>
-            </div>
-            <div className="flex flex-col gap-3 md:flex-row md:items-center">
-              <CTAButton ctaKey="visitSchedule" />
-              <a href="#program" className="btn-outline w-full sm:w-auto">
-                Lihat Program Kembali
-              </a>
-            </div>
-          </AnimateIn>
+          <AuroraBackground className="rounded-[2.5rem] border border-white/70 bg-white/60 p-[1.5px]">
+            <AnimateIn className="relative flex flex-col gap-6 rounded-[2.5rem] bg-gradient-to-br from-secondary/10 via-white to-primary/10 p-10 text-center shadow-soft md:flex-row md:items-center md:justify-between md:text-left">
+              <div className="max-w-xl space-y-4">
+                <span className="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/60 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-secondary backdrop-blur-sm backdrop-saturate-150">
+                  Siap Bergabung
+                </span>
+                <h2 className="text-balance text-3xl font-semibold text-text sm:text-4xl">
+                  Lihat Langsung Bagaimana Anak-Anak Belajar dengan Gembira
+                </h2>
+                <p className="text-base leading-relaxed text-text-muted">
+                  Kami mengundang Anda untuk merasakan sendiri suasana hangat di kelas kami. Lihat sentra belajar yang interaktif dan temukan bagaimana projek seru kami menumbuhkan kreativitas serta rasa percaya diri anak.
+                </p>
+              </div>
+              <div className="flex flex-col gap-3 md:flex-row md:items-center">
+                <CTAButton ctaKey="visitSchedule" />
+                <a href="#program" className="btn-outline w-full sm:w-auto">
+                  Lihat Program Kembali
+                </a>
+              </div>
+            </AnimateIn>
+          </AuroraBackground>
         </PageSection>
       </main>
   );

--- a/components/reactbits/AnimatedCounter.tsx
+++ b/components/reactbits/AnimatedCounter.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useInView } from "framer-motion";
+
+import { cn } from "@/lib/utils";
+
+type AnimatedCounterProps = {
+  value: string;
+  className?: string;
+  durationMs?: number;
+};
+
+type ParsedValue = {
+  prefix: string;
+  number: number | null;
+  suffix: string;
+  decimals: number;
+};
+
+const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
+
+function parseValue(rawValue: string): ParsedValue {
+  const value = rawValue.trim();
+  const match = value.match(/^(?<prefix>[^\d+-]*)(?<number>[-+]?\d+[\d.,]*)(?<suffix>.*)$/);
+
+  if (!match || !match.groups?.number) {
+    return {
+      prefix: "",
+      number: null,
+      suffix: value,
+      decimals: 0,
+    };
+  }
+
+  const prefix = match.groups.prefix ?? "";
+  const suffix = match.groups.suffix ?? "";
+  const numericPart = match.groups.number.replaceAll(".", "").replace(",", ".");
+  const number = Number.parseFloat(numericPart);
+  const decimals = match.groups.number.includes(",") || match.groups.number.includes(".") ? 1 : 0;
+
+  if (!Number.isFinite(number)) {
+    return {
+      prefix,
+      number: null,
+      suffix,
+      decimals: 0,
+    };
+  }
+
+  return {
+    prefix,
+    number,
+    suffix,
+    decimals,
+  };
+}
+
+export default function AnimatedCounter({ value, className, durationMs = 1600 }: AnimatedCounterProps) {
+  const { prefix, number, suffix, decimals } = useMemo(() => parseValue(value), [value]);
+  const ref = useRef<HTMLSpanElement>(null);
+  const isInView = useInView(ref, { once: true, margin: "-20% 0px" });
+  const [displayValue, setDisplayValue] = useState(value);
+
+  useEffect(() => {
+    if (!isInView || number === null) {
+      return;
+    }
+
+    let animationFrame: number;
+    const start = performance.now();
+
+    const step = (now: number) => {
+      const elapsed = now - start;
+      const progress = Math.min(elapsed / durationMs, 1);
+      const eased = easeOutCubic(progress);
+      const current = number * eased;
+      const formatted = new Intl.NumberFormat("id-ID", {
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals,
+      }).format(current);
+      setDisplayValue(`${prefix}${formatted}${suffix}`.trim());
+      if (progress < 1) {
+        animationFrame = requestAnimationFrame(step);
+      }
+    };
+
+    animationFrame = requestAnimationFrame(step);
+
+    return () => {
+      cancelAnimationFrame(animationFrame);
+    };
+  }, [decimals, durationMs, isInView, number, prefix, suffix]);
+
+  useEffect(() => {
+    if (number === null) {
+      setDisplayValue(value);
+    }
+  }, [number, value]);
+
+  return (
+    <span ref={ref} className={cn("tabular-nums", className)}>
+      {displayValue}
+    </span>
+  );
+}

--- a/components/reactbits/AuroraBackground.tsx
+++ b/components/reactbits/AuroraBackground.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { type PropsWithChildren } from "react";
+
+import { cn } from "@/lib/utils";
+
+const gradients = [
+  {
+    className: "-top-24 -left-24 h-64 w-64",
+    from: "rgba(255, 186, 73, 0.28)",
+    via: "rgba(255, 109, 77, 0.24)",
+    to: "rgba(255, 207, 150, 0.18)",
+  },
+  {
+    className: "top-1/3 -right-28 h-80 w-80",
+    from: "rgba(179, 214, 255, 0.25)",
+    via: "rgba(130, 183, 255, 0.2)",
+    to: "rgba(102, 126, 234, 0.18)",
+  },
+  {
+    className: "bottom-0 left-1/4 h-96 w-96",
+    from: "rgba(255, 255, 255, 0.35)",
+    via: "rgba(233, 248, 255, 0.28)",
+    to: "rgba(179, 239, 241, 0.24)",
+  },
+];
+
+type AuroraBackgroundProps = PropsWithChildren<{
+  className?: string;
+}>;
+
+export function AuroraBackground({ className, children }: AuroraBackgroundProps) {
+  return (
+    <div className={cn("relative isolate overflow-hidden", className)}>
+      <div className="pointer-events-none absolute inset-0 select-none opacity-95" aria-hidden="true">
+        {gradients.map((gradient, index) => (
+          <motion.div
+            key={gradient.className}
+            className={cn("absolute rounded-full blur-3xl", gradient.className)}
+            style={{
+              background: `radial-gradient(circle at 50% 50%, ${gradient.from} 0%, ${gradient.via} 50%, ${gradient.to} 100%)`,
+            }}
+            animate={{
+              scale: [1, 1.05, 1],
+              opacity: [0.65, 1, 0.65],
+            }}
+            transition={{
+              duration: 12 + index * 2,
+              repeat: Infinity,
+              repeatType: "mirror",
+              ease: "easeInOut",
+            }}
+          />
+        ))}
+        <motion.div
+          className="absolute inset-x-0 bottom-[-40%] h-[60%] bg-gradient-to-t from-secondary/20 via-transparent to-transparent"
+          animate={{ opacity: [0.6, 0.8, 0.6] }}
+          transition={{ duration: 10, repeat: Infinity, ease: "easeInOut" }}
+        />
+      </div>
+      <div className="relative">{children}</div>
+    </div>
+  );
+}
+
+export default AuroraBackground;

--- a/components/reactbits/StickyScrollReveal.tsx
+++ b/components/reactbits/StickyScrollReveal.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { motion } from "framer-motion";
+
+import { cn } from "@/lib/utils";
+
+type StickyScrollRevealItem = {
+  id: string;
+  title: string;
+  subtitle?: string;
+  description: string;
+  highlights?: string[];
+  icon?: string;
+};
+
+type StickyScrollRevealProps = {
+  eyebrow?: string;
+  heading: string;
+  description: string;
+  items: StickyScrollRevealItem[];
+  className?: string;
+};
+
+export default function StickyScrollReveal({ eyebrow, heading, description, items, className }: StickyScrollRevealProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  useEffect(() => {
+    const observers: IntersectionObserver[] = [];
+
+    itemRefs.current.forEach((element, index) => {
+      if (!element) return;
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              setActiveIndex(index);
+            }
+          });
+        },
+        {
+          root: null,
+          threshold: 0.35,
+          rootMargin: "-30% 0px -40%",
+        },
+      );
+
+      observer.observe(element);
+      observers.push(observer);
+    });
+
+    return () => {
+      observers.forEach((observer) => observer.disconnect());
+    };
+  }, [items.length]);
+
+  const activeItem = useMemo(() => items[activeIndex] ?? items[0], [items, activeIndex]);
+
+  return (
+    <section className={cn("relative", className)}>
+      <div className="grid gap-10 lg:grid-cols-[0.85fr,1.15fr] lg:items-start">
+        <motion.aside
+          initial={{ opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.4 }}
+          transition={{ duration: 0.45 }}
+          className="sticky top-24 space-y-6 rounded-3xl border border-white/60 bg-white/70 p-8 shadow-soft backdrop-blur-xl backdrop-saturate-150"
+        >
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-secondary">
+              {eyebrow ?? "Program Utama"}
+            </p>
+            <h3 className="text-2xl font-semibold text-text">{heading}</h3>
+            <p className="text-base text-text-muted">{description}</p>
+          </div>
+          <div className="space-y-3 rounded-2xl border border-secondary/40 bg-secondary/5 p-5">
+            <p className="text-sm font-semibold uppercase tracking-wide text-secondary/90">Sorotan saat ini</p>
+            <div className="space-y-1">
+              <p className="text-lg font-semibold text-text">{activeItem.title}</p>
+              {activeItem.subtitle ? (
+                <p className="text-sm font-medium text-secondary">{activeItem.subtitle}</p>
+              ) : null}
+            </div>
+            <p className="text-sm leading-relaxed text-text-muted">{activeItem.description}</p>
+            {activeItem.highlights && activeItem.highlights.length > 0 ? (
+              <ul className="space-y-2 text-sm text-text">
+                {activeItem.highlights.map((highlight) => (
+                  <li key={highlight} className="flex items-start gap-2">
+                    <span className="mt-1 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-secondary" />
+                    <span>{highlight}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        </motion.aside>
+
+        <div className="space-y-6">
+          {items.map((item, index) => (
+            <motion.div
+              key={item.id}
+              ref={(element) => {
+                itemRefs.current[index] = element;
+              }}
+              initial={{ opacity: 0, y: 32 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.35 }}
+              transition={{ duration: 0.5, delay: index * 0.05 }}
+              className={cn(
+                "relative overflow-hidden rounded-3xl border border-white/60 bg-white/60 p-7 shadow-soft backdrop-blur-lg transition-all duration-500",
+                activeIndex === index ? "ring-2 ring-secondary/50" : "hover:border-secondary/50",
+              )}
+            >
+              <div className="absolute inset-0 bg-gradient-to-br from-secondary/5 via-white to-primary/10 opacity-80" aria-hidden="true" />
+              <div className="relative space-y-4">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-sm font-semibold uppercase tracking-wide text-secondary">{item.subtitle}</p>
+                    <h4 className="text-xl font-semibold text-text">{item.title}</h4>
+                  </div>
+                  {item.icon ? (
+                    <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-secondary/10 text-2xl">
+                      {item.icon}
+                    </span>
+                  ) : null}
+                </div>
+                <p className="text-sm leading-relaxed text-text-muted">{item.description}</p>
+                {item.highlights && item.highlights.length > 0 ? (
+                  <ul className="space-y-2 text-sm text-text-muted">
+                    {item.highlights.map((highlight) => (
+                      <li key={highlight} className="flex items-start gap-3">
+                        <span className="mt-1 inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+                          {index + 1}
+                        </span>
+                        {highlight}
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/reactbits/TimelineSteps.tsx
+++ b/components/reactbits/TimelineSteps.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+
+import { cn } from "@/lib/utils";
+
+type TimelineStep = {
+  key: string;
+  title: string;
+  description: string;
+  icon: string;
+  href: string;
+  linkLabel: string;
+};
+
+type TimelineStepsProps = {
+  steps: readonly TimelineStep[];
+  className?: string;
+};
+
+export default function TimelineSteps({ steps, className }: TimelineStepsProps) {
+  return (
+    <ol className={cn("relative grid gap-6 lg:grid-cols-2", className)}>
+      <div className="pointer-events-none absolute inset-0 hidden bg-gradient-to-b from-transparent via-white/30 to-transparent lg:block" aria-hidden="true" />
+      {steps.map((step, index) => (
+        <motion.li
+          key={step.key}
+          initial={{ opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.4 }}
+          transition={{ duration: 0.45, delay: index * 0.05 }}
+          className="group relative flex flex-col gap-5 overflow-hidden rounded-3xl border border-white/60 bg-white/70 p-7 shadow-soft backdrop-blur-xl backdrop-saturate-150"
+        >
+          <span className="absolute left-6 top-0 h-1.5 w-12 rounded-full bg-primary/40 transition-transform duration-500 group-hover:translate-x-2" aria-hidden="true" />
+          <div className="flex items-center gap-3">
+            <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/12 text-2xl">{step.icon}</span>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-secondary">Langkah {index + 1}</p>
+              <h3 className="mt-1 text-lg font-semibold text-text">{step.title}</h3>
+            </div>
+          </div>
+          <p className="text-sm leading-relaxed text-text-muted">{step.description}</p>
+          <div className="flex items-center justify-between gap-3 text-sm font-semibold text-primary">
+            <Link href={step.href} className="inline-flex items-center gap-2 transition-transform duration-300 group-hover:translate-x-1">
+              {step.linkLabel}
+              <span aria-hidden="true">→</span>
+            </Link>
+            <span className="rounded-full border border-primary/30 bg-primary/5 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary/80">
+              Siap dilanjutkan
+            </span>
+          </div>
+          <span className="pointer-events-none absolute inset-0 rounded-3xl border border-white/40 opacity-0 transition-opacity duration-300 group-hover:opacity-100" aria-hidden="true" />
+        </motion.li>
+      ))}
+    </ol>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap the home hero and final CTA in a reusable aurora background while animating stats with a counter component inspired by Reactbits patterns
- replace the onboarding grid with a motion timeline and add a sticky scroll reveal layout for program cards to keep context visible during scroll
- refresh testimonials with a marquee slider and add supporting animation utilities for the new interactions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbec46dd7c832fb367af07a4bf9d58