### PR TITLE
Refactor homepage into modular sections and centralize copy

### DIFF
--- a/app/types/home.ts
+++ b/app/types/home.ts
@@ -25,6 +25,20 @@ export type HomeJourneyItem = {
   icon: string;
 };
 
+export type HomeOnboardingStep = {
+  key: string;
+  title: string;
+  description: string;
+  icon: string;
+  href: string;
+  linkLabel: string;
+};
+
+export type HomeAgendaItem = {
+  time: string;
+  description: string;
+};
+
 export type HomeFaq = {
   question: string;
   answer: string;

--- a/components/home/HomeDailyAgenda.tsx
+++ b/components/home/HomeDailyAgenda.tsx
@@ -1,41 +1,59 @@
 import AnimateIn from "@/components/AnimateIn";
+import { cardSurfaceVariants, CardSurface } from "@/components/ui/CardSurface";
+import type { HomeAgendaItem } from "@/app/types/home";
+import { cn } from "@/lib/utils";
 
-const agendaItems = [
-  {
-    time: "07.00",
-    description: "Penyambutan hangat, doa, dan pemetaan emosi anak.",
-  },
-  {
-    time: "08.30",
-    description: "Diskusi nilai Pancasila dan eksplorasi budaya lokal.",
-  },
-  {
-    time: "10.00",
-    description: "Sentra pilihan: STEAM, literasi, seni, atau role play terarah.",
-  },
-];
+type FocusCard = {
+  title: string;
+  description: string;
+};
+
+type AgendaHeader = {
+  title: string;
+  badge: string;
+};
+
+type AgendaInfo = {
+  title: string;
+  description: string;
+  ratioLabel: string;
+  defaultNpsn: string;
+};
 
 type HomeDailyAgendaProps = {
+  items: HomeAgendaItem[];
+  header: AgendaHeader;
+  info: AgendaInfo;
+  focusCards: FocusCard[];
   npsn?: string;
   teacherStudentRatio?: string;
 };
 
 export default function HomeDailyAgenda({
+  items,
+  header,
+  info,
+  focusCards,
   npsn,
-  teacherStudentRatio = "1 : 8",
+  teacherStudentRatio,
 }: HomeDailyAgendaProps) {
+  const agendaClasses = cardSurfaceVariants({ tone: "translucent", padding: "none" });
+  const resolvedRatio = teacherStudentRatio ?? "1 : 8";
+  const resolvedNpsn = npsn ?? info.defaultNpsn;
+  const infoDescription = info.description.replace("{{npsn}}", resolvedNpsn);
+
   return (
     <AnimateIn>
-      <details className="group rounded-3xl border border-white/60 bg-white/60 shadow-soft backdrop-blur-lg backdrop-saturate-150 [&_summary::-webkit-details-marker]:hidden">
+      <details className={cn("group overflow-hidden", agendaClasses)}>
         <summary className="flex cursor-pointer items-center justify-between gap-4 rounded-3xl px-6 py-5 text-base font-semibold text-secondary transition-colors group-open:bg-white/70">
-          <span>Agenda Kurikulum Merdeka</span>
+          <span>{header.title}</span>
           <span className="inline-flex items-center gap-2 rounded-full bg-secondary/10 px-3 py-1 text-sm font-semibold text-secondary">
-            Projek Profil Pelajar Pancasila
+            {header.badge}
           </span>
         </summary>
         <div className="space-y-5 border-t border-white/60 bg-white/70 px-6 py-6">
           <ul className="space-y-3 text-base text-text-muted">
-            {agendaItems.map((item) => (
+            {items.map((item) => (
               <li key={item.time} className="flex items-start gap-3">
                 <span className="mt-0.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold">
                   {item.time}
@@ -44,31 +62,23 @@ export default function HomeDailyAgenda({
               </li>
             ))}
           </ul>
-          <div className="rounded-3xl border border-white/60 bg-white/60 p-5">
-            <p className="text-base font-semibold text-secondary">Lingkungan aman & terdata resmi</p>
-            <p className="mt-3 text-base leading-relaxed text-text-muted">
-              Terdaftar dengan NPSN {npsn ?? "20351273"}, area 440 m² terpantau, dan peralatan ramah anak untuk belajar yang nyaman.
-            </p>
+          <CardSurface tone="translucent" padding="lg">
+            <p className="text-base font-semibold text-secondary">{info.title}</p>
+            <p className="mt-3 text-base leading-relaxed text-text-muted">{infoDescription}</p>
             <div className="mt-4 flex items-center gap-3 text-base font-semibold text-text">
               <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/15 text-lg" aria-hidden="true">
                 😊
               </span>
-              Rasio guru : anak {teacherStudentRatio}
+              {info.ratioLabel} {resolvedRatio}
             </div>
-          </div>
+          </CardSurface>
           <div className="grid gap-4 sm:grid-cols-2">
-            <div className="rounded-3xl border border-white/60 bg-white/60 p-5">
-              <p className="text-base font-semibold text-secondary">Fokus Harian</p>
-              <p className="mt-2 text-base text-text-muted">
-                Nilai agama & budi pekerti, jati diri, serta kecakapan literasi sesuai fase fondasi.
-              </p>
-            </div>
-            <div className="rounded-3xl border border-white/60 bg-white/60 p-5">
-              <p className="text-base font-semibold text-secondary">Asesmen Autentik</p>
-              <p className="mt-2 text-base text-text-muted">
-                Jurnal perkembangan, dokumentasi karya, dan umpan balik personal setiap pekan.
-              </p>
-            </div>
+            {focusCards.map((card) => (
+              <CardSurface key={card.title} tone="translucent" padding="lg">
+                <p className="text-base font-semibold text-secondary">{card.title}</p>
+                <p className="mt-2 text-base text-text-muted">{card.description}</p>
+              </CardSurface>
+            ))}
           </div>
         </div>
       </details>

--- a/components/home/HomePageContent.tsx
+++ b/components/home/HomePageContent.tsx
@@ -1,11 +1,6 @@
-'use client';
+"use client";
 
-import FaqAccordion from "@/components/FaqAccordion";
-import CTAButton from "@/components/CTAButton";
 import TestimonialList from "@/components/TestimonialList";
-import PageSection from "@/components/layout/PageSection";
-import SectionHeader from "@/components/layout/SectionHeader";
-import HomeDailyAgenda from "./HomeDailyAgenda";
 import type {
   HomeCredential,
   HomeCurriculumPillar,
@@ -18,19 +13,36 @@ import type {
 } from "@/app/types/home";
 import type { Post as BlogPost } from "@/lib/blog";
 import type { Testimonial } from "@/lib/types/site";
-import { ArrowRight, CheckCircle } from "react-bootstrap-icons";
-import Link from "next/link";
-import Image from "next/image";
-import AnimateIn from "@/components/AnimateIn";
-import { homeJourney as homeJourneyStatic } from "@/content/home";
 import {
-  ppdbMetaDescription,
-  syaratDanKetentuan as ppdbRequirementsStatic,
-} from "@/content/ppdb";
-import { AuroraBackground } from "@/components/reactbits/AuroraBackground";
-import AnimatedCounter from "@/components/reactbits/AnimatedCounter";
-import TimelineSteps from "@/components/reactbits/TimelineSteps";
-import StickyScrollReveal from "@/components/reactbits/StickyScrollReveal";
+  homeHero,
+  homeOnboardingCopy,
+  homeHighlightsCopy,
+  homeCredentialsCopy,
+  homeCurriculumCopy,
+  homeProgramsCopy,
+  homeExperienceCopy,
+  homeDailyAgenda,
+  homeBlogCopy,
+  homeFaqCopy,
+  homeFinalCtaCopy,
+} from "@/content/home";
+import { ppdbMetaDescription, syaratDanKetentuan as ppdbRequirementsStatic } from "@/content/ppdb";
+import {
+  buildOnboardingSteps,
+  extractCredentialValue,
+  extractTeacherStudentRatio,
+} from "@/lib/home";
+
+import { HeroSection } from "./sections/HeroSection";
+import { OnboardingSection } from "./sections/OnboardingSection";
+import { HighlightsSection } from "./sections/HighlightsSection";
+import { CredentialsSection } from "./sections/CredentialsSection";
+import { CurriculumSection } from "./sections/CurriculumSection";
+import { ProgramsSection } from "./sections/ProgramsSection";
+import { DailyExperienceSection } from "./sections/DailyExperienceSection";
+import { BlogSection } from "./sections/BlogSection";
+import { FaqSection } from "./sections/FaqSection";
+import { FinalCtaSection } from "./sections/FinalCtaSection";
 
 type HomePageContentProps = {
   schoolName: string;
@@ -59,9 +71,8 @@ export default function HomePageContent({
   blogPosts,
   testimonials,
 }: HomePageContentProps) {
-  const teacherStudentRatio =
-    stats.find((item) => item.label.toLowerCase().includes("rasio"))?.value ?? "1 : 8";
-  const schoolNpsn = credentials.find((item) => item.label.toLowerCase() === "npsn")?.value;
+  const teacherStudentRatio = extractTeacherStudentRatio(stats);
+  const schoolNpsn = extractCredentialValue(credentials, "npsn");
 
   const biayaRequirement = ppdbRequirementsStatic.find((item) =>
     item.title.toLowerCase().includes("biaya"),
@@ -70,484 +81,37 @@ export default function HomePageContent({
     item.title.toLowerCase().includes("dokumen"),
   );
 
-  const onboardingSteps = [
-    {
-      key: "routine",
-      href: "#pengalaman",
-      icon: "🧭",
-      title: "Jelajahi Rutinitas & Lingkungan",
-      description:
-        journey[0]?.description ??
-        homeJourneyStatic[0]?.description ??
-        "Kenali agenda harian, suasana kelas, dan cara kami mendampingi anak agar cepat nyaman.",
-      linkLabel: "Lihat pengalaman harian",
-    },
-    {
-      key: "cost",
-      href: "/biaya",
-      icon: "💡",
-      title: "Hitung Investasi Pendidikan",
-      description:
-        biayaRequirement?.description ??
-        "Pelajari struktur biaya, jadwal pembayaran, dan opsi keringanan agar rencana keluarga tetap nyaman.",
-      linkLabel: "Buka rincian biaya",
-    },
-    {
-      key: "documents",
-      href: "/ppdb#requirements",
-      icon: "🗂️",
-      title: "Lengkapi Dokumen Awal",
-      description:
-        documentRequirement?.description ??
-        "Siapkan akta kelahiran, KK, dan identitas orang tua agar proses administrasi berjalan mulus.",
-      linkLabel: "Lihat daftar dokumen",
-    },
-    {
-      key: "apply",
-      href: "/kontak",
-      icon: "📍",
-      title: "Konfirmasi Kuota & Jadwal",
-      description:
-        ppdbMetaDescription ??
-        "Hubungi admin TK Kartikasari untuk mengetahui status kuota terbaru, daftar tunggu, dan jadwal pembaruan PPDB.",
-      linkLabel: "Hubungi admin sekarang",
-    },
-  ] as const;
+  const onboardingSteps = buildOnboardingSteps({
+    journey,
+    biayaDescription: biayaRequirement?.description,
+    documentDescription: documentRequirement?.description,
+    metaDescription: ppdbMetaDescription,
+  });
 
   return (
-      <main>
-        {/* Section 1: Hero (Kail) */}
-        <AuroraBackground className="rounded-b-[2.5rem] border-b border-white/60 bg-gradient-to-br from-white via-secondary/10 to-primary/10">
-          <PageSection
-            padding="none"
-            containerClassName="relative grid gap-16 pb-24 pt-20 lg:grid-cols-[1.1fr,0.9fr] lg:items-center"
-          >
-            <div
-              className="relative space-y-8"
-            >
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/60 px-4 py-2 text-sm font-semibold text-secondary shadow-soft backdrop-blur-sm backdrop-saturate-150">
-              <span className="h-2.5 w-2.5 rounded-full bg-secondary" aria-hidden="true" />
-              {schoolName} • Kurikulum Merdeka PAUD
-            </span>
-            <h1 className="text-balance text-4xl font-bold leading-tight text-text sm:text-5xl">
-              Awal Terbaik untuk Si Kecil: Belajar Sambil Ceria di Rumah Kedua Mereka
-            </h1>
-            <p className="max-w-xl text-pretty text-lg text-text-muted sm:text-xl">
-              Sebagai TK berpengalaman di Bantarsari, kami menggabungkan tradisi pengajaran yang hangat dengan Kurikulum Merdeka. Kami memastikan setiap anak mendapat perhatian personal dalam lingkungan yang aman, sehingga mereka tumbuh percaya diri, kreatif, dan siap untuk jenjang sekolah berikutnya.
-            </p>
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
-              <CTAButton ctaKey="heroVisit" />
-              <Link href="/ppdb" className="btn-secondary w-full sm:w-auto">
-                Info PPDB
-              </Link>
-            </div>
-            <div className="grid gap-6 pt-6 sm:grid-cols-2 md:grid-cols-3">
-              {stats.map((item) => (
-                <div
-                  key={item.label}
-                  className="rounded-3xl border border-white/60 bg-white/60 p-5 text-left shadow-soft backdrop-blur-lg backdrop-saturate-150"
-                >
-                  <p className="text-3xl font-bold text-text">
-                    <AnimatedCounter value={item.value} />
-                  </p>
-                  <p className="mt-1 text-base text-text-muted">{item.label}</p>
-                </div>
-              ))}
-            </div>
-            </div>
-
-            <AnimateIn className="relative flex justify-center">
-              <div className="absolute -top-12 right-6 h-40 w-40 rounded-full bg-accent/30 blur-2xl" aria-hidden="true" />
-              <div className="absolute -bottom-6 left-2 h-36 w-36 rounded-full bg-secondary/25 blur-2xl md:-bottom-10" aria-hidden="true" />
-              <div className="relative w-full max-w-md space-y-5 rounded-[2.5rem] border border-white/60 bg-white/70 p-8 text-center shadow-soft backdrop-blur-xl backdrop-saturate-150">
-                <p className="text-lg font-semibold text-secondary">Belajar aktif & penuh perhatian</p>
-                <p className="text-base leading-relaxed text-text-muted">
-                  Kelas kecil dengan guru pendamping personal membantu anak cepat nyaman, bereksplorasi, dan siap melanjutkan ke jenjang berikutnya.
-                </p>
-                <div className="flex items-center justify-center gap-3 text-base font-semibold text-text">
-                  <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/15 text-lg" aria-hidden="true">
-                    😊
-                  </span>
-                  Rasio guru : anak {teacherStudentRatio}
-                </div>
-              </div>
-            </AnimateIn>
-          </PageSection>
-        </AuroraBackground>
-
-        {/* Section 2: Langkah Onboarding */}
-        <PageSection
-          className="relative border-y border-white/50 bg-gradient-to-br from-primary/10 via-white to-secondary/10"
-          padding="tight"
-        >
-          <div className="pointer-events-none absolute inset-0" aria-hidden="true">
-            <div className="absolute left-8 top-8 h-40 w-40 rounded-full bg-primary/20 blur-3xl" />
-            <div className="absolute right-12 bottom-12 h-48 w-48 rounded-full bg-secondary/20 blur-3xl" />
-          </div>
-          <AnimateIn className="relative">
-            <SectionHeader
-              align="center"
-              eyebrow="Mulai dari Sini"
-              eyebrowVariant="primary"
-              title="Alur singkat bergabung bersama TK Kartikasari"
-              description="Ikuti empat langkah ringkas ini untuk mengenal sekolah, menyiapkan berkas, dan memastikan kuota sebelum periode pendaftaran tatap muka dibuka."
-            />
-          </AnimateIn>
-          <TimelineSteps steps={onboardingSteps} className="relative mt-12" />
-          <div className="relative mt-12 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-center">
-            <Link href="/ppdb" className="btn-primary w-full sm:w-auto">
-              Info PPDB 2025/2026
-            </Link>
-            <CTAButton ctaKey="visitSchedule" className="w-full sm:w-auto" />
-          </div>
-        </PageSection>
-
-        {/* Section 3: Keunggulan/Highlights (Janji Utama) - REVISED */}
-        <PageSection
-          className="relative border-y border-white/50 bg-white/50 backdrop-blur-sm backdrop-saturate-150"
-          padding="tight"
-        >
-          <AnimateIn>
-            <SectionHeader
-              align="center"
-              eyebrow="Mengapa orang tua mempercayakan anaknya"
-              eyebrowVariant="primary"
-              title="Tiga janji utama kami untuk ketenangan Ayah & Bunda"
-              description="Komitmen kami adalah menciptakan lingkungan belajar yang aman secara legal, nyaman untuk anak, dan berakar pada nilai-nilai keindonesiaan."
-            />
-          </AnimateIn>
-          <div className="mt-12 grid gap-6 md:grid-cols-3">
-            {highlights.map((item) => (
-              <AnimateIn
-                key={item.title}
-                className="card h-full border-white/60 bg-white/70 p-7 text-left backdrop-blur-xl backdrop-saturate-150"
-              >
-                <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/15 text-2xl" aria-hidden="true">
-                  {item.icon}
-                </span>
-                <h3 className="mt-6 text-xl font-semibold text-text">{item.title}</h3>
-                <p className="mt-3 text-base leading-relaxed text-text-muted">{item.description}</p>
-              </AnimateIn>
-            ))}
-          </div>
-        </PageSection>
-
-        {/* Section 3: Kredensial & Sejarah (Bukti Kepercayaan) - REVISED */}
-        <PageSection className="relative" padding="tight">
-          <AnimateIn
-            className="space-y-8"
-          >
-            <SectionHeader
-              eyebrow="Bukti Kepercayaan Anda"
-              eyebrowVariant="secondary"
-              title="Kredensial Resmi dan Perjalanan Panjang yang Teruji"
-              description="Seluruh informasi sekolah tersimpan di basis data Kemendikbudristek dan diperkuat oleh sejarah layanan kami untuk keluarga Bantarsari."
-            />
-            <div className="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
-              <div className="card h-full space-y-5 border-white/70 bg-white/70 p-7 shadow-soft backdrop-blur-xl backdrop-saturate-150">
-                <h3 className="text-2xl font-semibold text-text">Legalitas & Info Resmi</h3>
-                <ul className="space-y-4">
-                  {credentials.map((item) => (
-                    <li
-                      key={item.label}
-                      className="rounded-3xl border border-white/60 bg-white/60 p-4 transition-all duration-300 backdrop-blur-lg backdrop-saturate-150 hover:-translate-y-1 hover:border-secondary/60 hover:shadow-lg"
-                    >
-                      <p className="text-xs font-semibold uppercase tracking-wide text-secondary">{item.label}</p>
-                      <p className="mt-1 text-lg font-semibold text-text">{item.value}</p>
-                      <p className="mt-1 text-sm leading-relaxed text-text-muted">{item.description}</p>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-              <div className="card h-full space-y-5 border-white/70 bg-gradient-to-br from-primary/10 via-white to-secondary/10 p-7 shadow-soft backdrop-blur-xl backdrop-saturate-150">
-                <h3 className="text-2xl font-semibold text-text">Jejak Langkah Kami</h3>
-                <div className="relative">
-                  <span className="absolute left-4 top-2 bottom-2 w-px bg-secondary/30" aria-hidden="true" />
-                  <ul className="space-y-6">
-                    {timeline.map((milestone) => (
-                      <li key={`${milestone.year}-${milestone.title}`} className="relative pl-10">
-                        <span className="absolute left-0 top-1 inline-flex h-8 w-8 items-center justify-center rounded-full bg-secondary-50 text-sm font-semibold text-secondary">
-                          {milestone.year}
-                        </span>
-                        <div className="space-y-1">
-                          <p className="text-base font-semibold text-text">{milestone.title}</p>
-                          <p className="text-sm leading-relaxed text-text-muted">{milestone.description}</p>
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </AnimateIn>
-        </PageSection>
-
-        {/* Section 4: Pilar Kurikulum (Filosofi) */}
-        <PageSection
-          id="kurikulum-merdeka"
-          className="bg-gradient-to-br from-secondary/10 via-white to-primary/10"
-          padding="tight"
-        >
-          <AnimateIn
-            className="space-y-8"
-          >
-            <SectionHeader
-              eyebrow="Filosofi Pendidikan Kami"
-              eyebrowVariant="secondary"
-              title="Tiga Pilar Kami dalam Membentuk Karakter Anak"
-              description="Kami fokus pada tiga area utama untuk memastikan anak tidak hanya pintar, tetapi juga tumbuh menjadi pribadi yang baik, bangga pada budayanya, dan siap untuk belajar lebih lanjut."
-            />
-            <div className="grid gap-6 md:grid-cols-3">
-              {curriculumPillars.map((pillar) => (
-                <AnimateIn
-                  key={pillar.title}
-                  className="card h-full border-white/70 bg-white/70 p-7 text-left shadow-soft backdrop-blur-xl backdrop-saturate-150"
-                >
-                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-secondary">
-                    {pillar.subtitle}
-                  </p>
-                  <h3 className="mt-3 text-2xl font-semibold text-text">{pillar.title}</h3>
-                  <ul className="mt-5 space-y-2 text-base text-text-muted">
-                    {pillar.points.map((point) => (
-                      <li key={point} className="flex items-start gap-3">
-                        <CheckCircle className="mt-1 h-5 w-5 flex-shrink-0 text-primary" aria-hidden="true" />
-                        {point}
-                      </li>
-                    ))}
-                  </ul>
-                </AnimateIn>
-              ))}
-            </div>
-          </AnimateIn>
-        </PageSection>
-
-        {/* Section 5: Program & Aktivitas Harian (Eksekusi) */}
-        <PageSection id="program" padding="tight">
-          <AnimateIn className="max-w-3xl space-y-6">
-            <SectionHeader
-              eyebrow="Program Kurikulum Merdeka"
-              eyebrowVariant="secondary"
-              title="Jalur Belajar yang Disesuaikan untuk Setiap Anak"
-              description="Guru inti dan guru pendamping berkolaborasi untuk menyeimbangkan pengembangan karakter, kemampuan dasar, dan kegembiraan bermain melalui projek-projek yang relevan dengan dunia anak."
-            />
-            <ul className="space-y-3 text-base text-text-muted">
-              <li className="flex items-start gap-3">
-                <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary" aria-hidden="true">
-                  1
-                </span>
-                Observasi minat, gaya belajar, serta diskusi orang tua untuk menentukan kebutuhan utama anak.
-              </li>
-              <li className="flex items-start gap-3">
-                <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary" aria-hidden="true">
-                  2
-                </span>
-                Perumusan tujuan pembelajaran Kurikulum Merdeka dan strategi diferensiasi setiap awal tema.
-              </li>
-              <li className="flex items-start gap-3">
-                <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary" aria-hidden="true">
-                  3
-                </span>
-                Pameran karya, refleksi projek P5, dan laporan portofolio terstruktur di akhir tema.
-              </li>
-            </ul>
-          </AnimateIn>
-          <StickyScrollReveal
-            eyebrow="Sorot Program"
-            heading="Pengalaman belajar yang menyatu dari playgroup hingga TK B"
-            description="Setiap kelas dirancang dengan ritme yang lembut, memadukan eksplorasi terstruktur dan bermain bebas supaya anak belajar tanpa kehilangan rasa aman."
-            items={programs.map((program, index) => ({
-              id: `${program.name}-${index}`,
-              title: program.name,
-              subtitle: program.age,
-              description: program.description,
-              highlights: program.points,
-              icon: "✨",
-            }))}
-            className="mt-12"
-          />
-        </PageSection>
-
-        <PageSection
-          id="pengalaman"
-          className="relative overflow-hidden"
-          padding="tight"
-          containerClassName="relative grid gap-12 lg:grid-cols-[0.9fr,1.1fr] lg:items-center"
-        >
-          <div className="absolute inset-0 bg-grid-dots [background-size:24px_24px] opacity-40" aria-hidden="true" />
-          <AnimateIn
-            className="relative space-y-6"
-          >
-            <SectionHeader
-              eyebrow="Aktivitas Harian"
-              eyebrowVariant="surface"
-              title="Transisi Lembut yang Menjaga Antusiasme Anak"
-              description="Rangkaian kegiatan mengikuti struktur Kurikulum Merdeka PAUD: mulai dari pembiasaan nilai, eksplorasi, hingga refleksi dan asesmen autentik."
-            />
-            <div className="rounded-3xl border border-white/60 bg-white/60 p-6 shadow-soft backdrop-blur-lg backdrop-saturate-150">
-              <p className="text-base font-semibold text-secondary">Kolaborasi dengan Orang Tua</p>
-              <p className="mt-3 text-base leading-relaxed text-text-muted">
-                Orang tua menerima ringkasan harian, refleksi projek P5, dan rekomendasi penguatan karakter untuk diterapkan di rumah.
-              </p>
-            </div>
-          </AnimateIn>
-          <div className="relative space-y-4">
-            <HomeDailyAgenda npsn={schoolNpsn} teacherStudentRatio={teacherStudentRatio} />
-            {journey.map((item) => (
-              <AnimateIn
-                key={item.title}
-                className="grid gap-4 rounded-3xl border border-white/60 bg-white/60 p-6 shadow-soft backdrop-blur-lg backdrop-saturate-150 sm:grid-cols-[auto,1fr] sm:items-center"
-              >
-                <div className="flex items-center gap-3">
-                  <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-secondary/10 text-2xl" aria-hidden="true">
-                    {item.icon}
-                  </span>
-                  <div>
-                    <p className="text-sm font-semibold text-secondary">{item.time} WIB</p>
-                    <p className="text-lg font-semibold text-text">{item.title}</p>
-                  </div>
-                </div>
-                <p className="text-base leading-relaxed text-text-muted sm:pl-4">{item.description}</p>
-              </AnimateIn>
-            ))}
-          </div>
-        </PageSection>
-        
-        {/* Section 6: Testimoni (Bukti Sosial) - REVISED POSITION */}
-        <TestimonialList testimonials={testimonials} />
-
-        {/* Section 7: Blog */}
-        <PageSection id="blog" padding="tight">
-          <AnimateIn
-            className="space-y-8"
-          >
-            <SectionHeader
-              eyebrow="Blog & Berita"
-              title="Tips Parenting dan Kegiatan Sekolah Terbaru"
-              description="Ikuti artikel terbaru dari kami untuk mendapatkan wawasan seputar dunia pendidikan anak usia dini dan melihat keseruan kegiatan di TK Kartikasari."
-            />
-            {blogPosts.length > 0 ? (
-              <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-                {blogPosts.slice(0, 3).map((post) => {
-                  const coverImage = post.coverImage;
-                  const publishedAt = post.date;
-                  const rawBody = post.body?.raw ?? '';
-                  const normalizedBody = rawBody
-                    .replace(/[#*_`>\-]/g, '')
-                    .replace(/\[(.*?)\]\(.*?\)/g, '$1')
-                    .replace(/<[^>]+>/g, ' ')
-                    .replace(/\s+/g, ' ')
-                    .trim();
-                  const description =
-                    normalizedBody.length > 160 ? `${normalizedBody.slice(0, 157)}...` : normalizedBody;
-
-                  return (
-                    <Link
-                      href={`/blog/${post.slug}`}
-                      key={post.slug}
-                      className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 group block rounded-2xl"
-                    >
-                      <article className="card h-full transform-gpu bg-white/60 shadow-soft backdrop-blur-xl transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-primary/20">
-                        <div className="relative aspect-[16/9] w-full overflow-hidden rounded-t-2xl">
-                          {coverImage ? (
-                            <Image
-                              src={coverImage}
-                              alt={post.title}
-                              fill
-                              className="object-cover"
-                              sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
-                              loading="lazy"
-                            />
-                          ) : (
-                            <div className="flex h-full w-full items-center justify-center bg-secondary/10 text-secondary">
-                              <span className="text-sm font-semibold">TK Kartikasari</span>
-                            </div>
-                          )}
-                        </div>
-                        <div className="flex h-full flex-col p-6">
-                          <p className="text-sm text-text-muted">
-                            {new Date(publishedAt).toLocaleDateString('id-ID', {
-                              year: 'numeric',
-                              month: 'long',
-                              day: 'numeric',
-                            })}
-                          </p>
-                          <h3 className="mt-2 text-lg font-semibold text-text">{post.title}</h3>
-                          <p className="mt-2 flex-grow text-sm text-text-muted">
-                            {description || 'Baca kisah terbaru dari TK Kartikasari.'}
-                          </p>
-                          <div className="mt-4 flex items-center text-sm font-semibold text-primary transition-transform group-hover:translate-x-1">
-                            Baca selengkapnya <ArrowRight className="ml-1 h-4 w-4" />
-                          </div>
-                        </div>
-                      </article>
-                    </Link>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className="card border-white/60 bg-white/70 p-8 text-center shadow-soft backdrop-blur-xl">
-                <h3 className="text-xl font-semibold text-text">Belum ada cerita terbaru</h3>
-                <p className="mt-3 text-base leading-relaxed text-text-muted">
-                  Tim kami sedang mempersiapkan artikel yang bisa membantu Ayah dan Bunda. Sementara itu, silakan jelajahi halaman lain atau hubungi kami untuk informasi langsung.
-                </p>
-                <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-center">
-                  <Link href="/program" className="btn-primary inline-flex items-center justify-center gap-2">
-                    Lihat program belajar
-                  </Link>
-                  <Link href="/kontak" className="btn-secondary inline-flex items-center justify-center gap-2">
-                    Hubungi kami
-                  </Link>
-                </div>
-              </div>
-            )}
-          </AnimateIn>
-        </PageSection>
-
-        {/* Section 8: FAQ */}
-        <PageSection
-          id="faq"
-          padding="tight"
-          containerClassName="grid gap-12 lg:grid-cols-[0.9fr,1fr] lg:items-start"
-        >
-          <AnimateIn
-            className="space-y-6"
-          >
-            <SectionHeader
-              eyebrow="Sering Ditanyakan"
-              title="Informasi Penting Seputar Pendaftaran"
-              description="Jika ada pertanyaan lain, kami dengan senang hati menjawab melalui WhatsApp ataupun ketika Anda berkunjung langsung."
-            />
-            <CTAButton ctaKey="faqInquiry" />
-          </AnimateIn>
-          <AnimateIn>
-            <FaqAccordion items={faqs} revealOnView className="space-y-4" />
-          </AnimateIn>
-        </PageSection>
-
-        {/* Section 9: CTA Final - REVISED */}
-        <PageSection className="relative pb-36" padding="tight">
-          <AuroraBackground className="rounded-[2.5rem] border border-white/70 bg-white/60 p-[1.5px]">
-            <AnimateIn className="relative flex flex-col gap-6 rounded-[2.5rem] bg-gradient-to-br from-secondary/10 via-white to-primary/10 p-10 text-center shadow-soft md:flex-row md:items-center md:justify-between md:text-left">
-              <div className="max-w-xl space-y-4">
-                <span className="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/60 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-secondary backdrop-blur-sm backdrop-saturate-150">
-                  Siap Bergabung
-                </span>
-                <h2 className="text-balance text-3xl font-semibold text-text sm:text-4xl">
-                  Lihat Langsung Bagaimana Anak-Anak Belajar dengan Gembira
-                </h2>
-                <p className="text-base leading-relaxed text-text-muted">
-                  Kami mengundang Anda untuk merasakan sendiri suasana hangat di kelas kami. Lihat sentra belajar yang interaktif dan temukan bagaimana projek seru kami menumbuhkan kreativitas serta rasa percaya diri anak.
-                </p>
-              </div>
-              <div className="flex flex-col gap-3 md:flex-row md:items-center">
-                <CTAButton ctaKey="visitSchedule" />
-                <a href="#program" className="btn-outline w-full sm:w-auto">
-                  Lihat Program Kembali
-                </a>
-              </div>
-            </AnimateIn>
-          </AuroraBackground>
-        </PageSection>
-      </main>
+    <main>
+      <HeroSection
+        schoolName={schoolName}
+        stats={stats}
+        teacherStudentRatio={teacherStudentRatio}
+        copy={homeHero}
+      />
+      <OnboardingSection steps={onboardingSteps} copy={homeOnboardingCopy} />
+      <HighlightsSection highlights={highlights} copy={homeHighlightsCopy} />
+      <CredentialsSection credentials={credentials} timeline={timeline} copy={homeCredentialsCopy} />
+      <CurriculumSection pillars={curriculumPillars} copy={homeCurriculumCopy} />
+      <ProgramsSection programs={programs} copy={homeProgramsCopy} />
+      <DailyExperienceSection
+        journey={journey}
+        teacherStudentRatio={teacherStudentRatio}
+        npsn={schoolNpsn}
+        copy={homeExperienceCopy}
+        agenda={homeDailyAgenda}
+      />
+      <TestimonialList testimonials={testimonials} />
+      <BlogSection posts={blogPosts} copy={homeBlogCopy} />
+      <FaqSection faqs={faqs} copy={homeFaqCopy} />
+      <FinalCtaSection copy={homeFinalCtaCopy} />
+    </main>
   );
 }

--- a/components/home/sections/BlogSection.tsx
+++ b/components/home/sections/BlogSection.tsx
@@ -1,0 +1,101 @@
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowRight } from "react-bootstrap-icons";
+
+import AnimateIn from "@/components/AnimateIn";
+import PageSection from "@/components/layout/PageSection";
+import SectionHeader from "@/components/layout/SectionHeader";
+import { CardSurface } from "@/components/ui/CardSurface";
+import type { Post as BlogPost } from "@/lib/blog";
+import { formatBlogDescription } from "@/lib/home";
+
+type BlogCopy = {
+  eyebrow: string;
+  title: string;
+  description: string;
+  emptyTitle: string;
+  emptyDescription: string;
+  emptyPrimaryCta: string;
+  emptySecondaryCta: string;
+};
+
+type BlogSectionProps = {
+  posts: BlogPost[];
+  copy: BlogCopy;
+};
+
+export function BlogSection({ posts, copy }: BlogSectionProps) {
+  const hasPosts = posts.length > 0;
+
+  return (
+    <PageSection id="blog" padding="tight">
+      <AnimateIn className="space-y-8">
+        <SectionHeader eyebrow={copy.eyebrow} title={copy.title} description={copy.description} />
+        {hasPosts ? (
+          <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+            {posts.slice(0, 3).map((post) => {
+              const coverImage = post.coverImage;
+              const publishedAt = post.date;
+              const rawBody = post.body?.raw ?? "";
+              const description = formatBlogDescription(rawBody) || "Baca kisah terbaru dari TK Kartikasari.";
+
+              return (
+                <Link
+                  href={`/blog/${post.slug}`}
+                  key={post.slug}
+                  className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 group block rounded-2xl"
+                >
+                  <article className="card h-full transform-gpu bg-white/60 shadow-soft backdrop-blur-xl transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-primary/20">
+                    <div className="relative aspect-[16/9] w-full overflow-hidden rounded-t-2xl">
+                      {coverImage ? (
+                        <Image
+                          src={coverImage}
+                          alt={post.title}
+                          fill
+                          className="object-cover"
+                          sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <div className="flex h-full w-full items-center justify-center bg-secondary/10 text-secondary">
+                          <span className="text-sm font-semibold">TK Kartikasari</span>
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex h-full flex-col p-6">
+                      <p className="text-sm text-text-muted">
+                        {new Date(publishedAt).toLocaleDateString("id-ID", {
+                          year: "numeric",
+                          month: "long",
+                          day: "numeric",
+                        })}
+                      </p>
+                      <h3 className="mt-2 text-lg font-semibold text-text">{post.title}</h3>
+                      <p className="mt-2 flex-grow text-sm text-text-muted">{description}</p>
+                      <div className="mt-4 flex items-center text-sm font-semibold text-primary transition-transform group-hover:translate-x-1">
+                        Baca selengkapnya <ArrowRight className="ml-1 h-4 w-4" />
+                      </div>
+                    </div>
+                  </article>
+                </Link>
+              );
+            })}
+          </div>
+        ) : (
+          <CardSurface tone="soft" padding="xl" className="text-center shadow-soft backdrop-blur-xl">
+            <h3 className="text-xl font-semibold text-text">{copy.emptyTitle}</h3>
+            <p className="mt-3 text-base leading-relaxed text-text-muted">{copy.emptyDescription}</p>
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-center">
+              <Link href="/program" className="btn-primary inline-flex items-center justify-center gap-2">
+                {copy.emptyPrimaryCta}
+              </Link>
+              <Link href="/kontak" className="btn-secondary inline-flex items-center justify-center gap-2">
+                {copy.emptySecondaryCta}
+              </Link>
+            </div>
+          </CardSurface>
+        )}
+      </AnimateIn>
+    </PageSection>
+  );
+}

--- a/components/home/sections/CredentialsSection.tsx
+++ b/components/home/sections/CredentialsSection.tsx
@@ -1,0 +1,72 @@
+import AnimateIn from "@/components/AnimateIn";
+import PageSection from "@/components/layout/PageSection";
+import SectionHeader from "@/components/layout/SectionHeader";
+import { CardSurface } from "@/components/ui/CardSurface";
+import type { HomeCredential, HomeTimelineMilestone } from "@/app/types/home";
+
+type CredentialsCopy = {
+  eyebrow: string;
+  title: string;
+  description: string;
+  legalTitle: string;
+  timelineTitle: string;
+};
+
+type CredentialsSectionProps = {
+  credentials: HomeCredential[];
+  timeline: HomeTimelineMilestone[];
+  copy: CredentialsCopy;
+};
+
+export function CredentialsSection({ credentials, timeline, copy }: CredentialsSectionProps) {
+  return (
+    <PageSection padding="tight" className="relative">
+      <AnimateIn className="space-y-8">
+        <SectionHeader
+          eyebrow={copy.eyebrow}
+          eyebrowVariant="secondary"
+          title={copy.title}
+          description={copy.description}
+        />
+        <div className="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
+          <CardSurface tone="soft" padding="lg" className="h-full space-y-5">
+            <h3 className="text-2xl font-semibold text-text">{copy.legalTitle}</h3>
+            <ul className="space-y-4">
+              {credentials.map((item) => (
+                <CardSurface
+                  key={item.label}
+                  tone="translucent"
+                  padding="md"
+                  className="transition-transform duration-300 hover:-translate-y-1 hover:border-secondary/60 hover:shadow-lg"
+                >
+                  <p className="text-xs font-semibold uppercase tracking-wide text-secondary">{item.label}</p>
+                  <p className="mt-1 text-lg font-semibold text-text">{item.value}</p>
+                  <p className="mt-1 text-sm leading-relaxed text-text-muted">{item.description}</p>
+                </CardSurface>
+              ))}
+            </ul>
+          </CardSurface>
+          <CardSurface tone="gradient" padding="lg" className="h-full space-y-5">
+            <h3 className="text-2xl font-semibold text-text">{copy.timelineTitle}</h3>
+            <div className="relative">
+              <span className="absolute left-4 top-2 bottom-2 w-px bg-secondary/30" aria-hidden="true" />
+              <ul className="space-y-6">
+                {timeline.map((milestone) => (
+                  <li key={`${milestone.year}-${milestone.title}`} className="relative pl-10">
+                    <span className="absolute left-0 top-1 inline-flex h-8 w-8 items-center justify-center rounded-full bg-secondary-50 text-sm font-semibold text-secondary">
+                      {milestone.year}
+                    </span>
+                    <div className="space-y-1">
+                      <p className="text-base font-semibold text-text">{milestone.title}</p>
+                      <p className="text-sm leading-relaxed text-text-muted">{milestone.description}</p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </CardSurface>
+        </div>
+      </AnimateIn>
+    </PageSection>
+  );
+}

--- a/components/home/sections/CurriculumSection.tsx
+++ b/components/home/sections/CurriculumSection.tsx
@@ -1,0 +1,51 @@
+import { CheckCircle } from "react-bootstrap-icons";
+
+import AnimateIn from "@/components/AnimateIn";
+import PageSection from "@/components/layout/PageSection";
+import SectionHeader from "@/components/layout/SectionHeader";
+import type { HomeCurriculumPillar } from "@/app/types/home";
+import { CardSurface } from "@/components/ui/CardSurface";
+
+type CurriculumCopy = {
+  eyebrow: string;
+  title: string;
+  description: string;
+};
+
+type CurriculumSectionProps = {
+  pillars: HomeCurriculumPillar[];
+  copy: CurriculumCopy;
+};
+
+export function CurriculumSection({ pillars, copy }: CurriculumSectionProps) {
+  return (
+    <PageSection id="kurikulum-merdeka" className="bg-gradient-to-br from-secondary/10 via-white to-primary/10" padding="tight">
+      <AnimateIn className="space-y-8">
+        <SectionHeader
+          eyebrow={copy.eyebrow}
+          eyebrowVariant="secondary"
+          title={copy.title}
+          description={copy.description}
+        />
+        <div className="grid gap-6 md:grid-cols-3">
+          {pillars.map((pillar) => (
+            <AnimateIn key={pillar.title}>
+              <CardSurface tone="soft" padding="lg" className="h-full text-left">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-secondary">{pillar.subtitle}</p>
+                <h3 className="mt-3 text-2xl font-semibold text-text">{pillar.title}</h3>
+                <ul className="mt-5 space-y-2 text-base text-text-muted">
+                  {pillar.points.map((point) => (
+                    <li key={point} className="flex items-start gap-3">
+                      <CheckCircle className="mt-1 h-5 w-5 flex-shrink-0 text-primary" aria-hidden="true" />
+                      {point}
+                    </li>
+                  ))}
+                </ul>
+              </CardSurface>
+            </AnimateIn>
+          ))}
+        </div>
+      </AnimateIn>
+    </PageSection>
+  );
+}

--- a/components/home/sections/DailyExperienceSection.tsx
+++ b/components/home/sections/DailyExperienceSection.tsx
@@ -1,0 +1,100 @@
+import AnimateIn from "@/components/AnimateIn";
+import PageSection from "@/components/layout/PageSection";
+import SectionHeader from "@/components/layout/SectionHeader";
+import { CardSurface } from "@/components/ui/CardSurface";
+import HomeDailyAgenda from "@/components/home/HomeDailyAgenda";
+import type { HomeJourneyItem, HomeAgendaItem } from "@/app/types/home";
+
+type ExperienceCopy = {
+  eyebrow: string;
+  title: string;
+  description: string;
+  parentCollab: {
+    title: string;
+    description: string;
+  };
+};
+
+type AgendaContent = {
+  header: {
+    title: string;
+    badge: string;
+  };
+  items: HomeAgendaItem[];
+  info: {
+    title: string;
+    description: string;
+    ratioLabel: string;
+    defaultNpsn: string;
+  };
+  focusCards: {
+    title: string;
+    description: string;
+  }[];
+};
+
+type DailyExperienceSectionProps = {
+  journey: HomeJourneyItem[];
+  teacherStudentRatio: string;
+  npsn?: string;
+  copy: ExperienceCopy;
+  agenda: AgendaContent;
+};
+
+export function DailyExperienceSection({
+  journey,
+  teacherStudentRatio,
+  npsn,
+  copy,
+  agenda,
+}: DailyExperienceSectionProps) {
+  return (
+    <PageSection
+      id="pengalaman"
+      className="relative overflow-hidden"
+      padding="tight"
+      containerClassName="relative grid gap-12 lg:grid-cols-[0.9fr,1.1fr] lg:items-center"
+    >
+      <div className="absolute inset-0 bg-grid-dots [background-size:24px_24px] opacity-40" aria-hidden="true" />
+      <AnimateIn className="relative space-y-6">
+        <SectionHeader
+          eyebrow={copy.eyebrow}
+          eyebrowVariant="surface"
+          title={copy.title}
+          description={copy.description}
+        />
+        <CardSurface tone="translucent" padding="lg">
+          <p className="text-base font-semibold text-secondary">{copy.parentCollab.title}</p>
+          <p className="mt-3 text-base leading-relaxed text-text-muted">{copy.parentCollab.description}</p>
+        </CardSurface>
+      </AnimateIn>
+      <div className="relative space-y-4">
+        <HomeDailyAgenda
+          items={agenda.items}
+          header={agenda.header}
+          info={agenda.info}
+          focusCards={agenda.focusCards}
+          npsn={npsn}
+          teacherStudentRatio={teacherStudentRatio}
+        />
+        {journey.map((item) => (
+          <AnimateIn
+            key={item.title}
+            className="grid gap-4 rounded-3xl border border-white/60 bg-white/60 p-6 shadow-soft backdrop-blur-lg backdrop-saturate-150 sm:grid-cols-[auto,1fr] sm:items-center"
+          >
+            <div className="flex items-center gap-3">
+              <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-secondary/10 text-2xl" aria-hidden="true">
+                {item.icon}
+              </span>
+              <div>
+                <p className="text-sm font-semibold text-secondary">{item.time} WIB</p>
+                <p className="text-lg font-semibold text-text">{item.title}</p>
+              </div>
+            </div>
+            <p className="text-base leading-relaxed text-text-muted sm:pl-4">{item.description}</p>
+          </AnimateIn>
+        ))}
+      </div>
+    </PageSection>
+  );
+}

--- a/components/home/sections/FaqSection.tsx
+++ b/components/home/sections/FaqSection.tsx
@@ -1,0 +1,31 @@
+import AnimateIn from "@/components/AnimateIn";
+import CTAButton from "@/components/CTAButton";
+import PageSection from "@/components/layout/PageSection";
+import SectionHeader from "@/components/layout/SectionHeader";
+import FaqAccordion from "@/components/FaqAccordion";
+import type { HomeFaq } from "@/app/types/home";
+
+type FaqCopy = {
+  eyebrow: string;
+  title: string;
+  description: string;
+};
+
+type FaqSectionProps = {
+  faqs: HomeFaq[];
+  copy: FaqCopy;
+};
+
+export function FaqSection({ faqs, copy }: FaqSectionProps) {
+  return (
+    <PageSection id="faq" padding="tight" containerClassName="grid gap-12 lg:grid-cols-[0.9fr,1fr] lg:items-start">
+      <AnimateIn className="space-y-6">
+        <SectionHeader eyebrow={copy.eyebrow} title={copy.title} description={copy.description} />
+        <CTAButton ctaKey="faqInquiry" />
+      </AnimateIn>
+      <AnimateIn>
+        <FaqAccordion items={faqs} revealOnView className="space-y-4" />
+      </AnimateIn>
+    </PageSection>
+  );
+}

--- a/components/home/sections/FinalCtaSection.tsx
+++ b/components/home/sections/FinalCtaSection.tsx
@@ -1,0 +1,39 @@
+import CTAButton from "@/components/CTAButton";
+import AnimateIn from "@/components/AnimateIn";
+import PageSection from "@/components/layout/PageSection";
+import { AuroraBackground } from "@/components/reactbits/AuroraBackground";
+
+type FinalCtaCopy = {
+  eyebrow: string;
+  title: string;
+  description: string;
+  secondaryCtaLabel: string;
+};
+
+type FinalCtaSectionProps = {
+  copy: FinalCtaCopy;
+};
+
+export function FinalCtaSection({ copy }: FinalCtaSectionProps) {
+  return (
+    <PageSection className="relative pb-36" padding="tight">
+      <AuroraBackground className="rounded-[2.5rem] border border-white/70 bg-white/60 p-[1.5px]">
+        <AnimateIn className="relative flex flex-col gap-6 rounded-[2.5rem] bg-gradient-to-br from-secondary/10 via-white to-primary/10 p-10 text-center shadow-soft md:flex-row md:items-center md:justify-between md:text-left">
+          <div className="max-w-xl space-y-4">
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/60 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-secondary backdrop-blur-sm backdrop-saturate-150">
+              {copy.eyebrow}
+            </span>
+            <h2 className="text-balance text-3xl font-semibold text-text sm:text-4xl">{copy.title}</h2>
+            <p className="text-base leading-relaxed text-text-muted">{copy.description}</p>
+          </div>
+          <div className="flex flex-col gap-3 md:flex-row md:items-center">
+            <CTAButton ctaKey="visitSchedule" />
+            <a href="#program" className="btn-outline w-full sm:w-auto">
+              {copy.secondaryCtaLabel}
+            </a>
+          </div>
+        </AnimateIn>
+      </AuroraBackground>
+    </PageSection>
+  );
+}

--- a/components/home/sections/HeroSection.tsx
+++ b/components/home/sections/HeroSection.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+
+import CTAButton from "@/components/CTAButton";
+import AnimateIn from "@/components/AnimateIn";
+import PageSection from "@/components/layout/PageSection";
+import { AuroraBackground } from "@/components/reactbits/AuroraBackground";
+import AnimatedCounter from "@/components/reactbits/AnimatedCounter";
+import type { HomeStat } from "@/app/types/home";
+import { CardSurface } from "@/components/ui/CardSurface";
+
+export type HeroCopy = {
+  badgeSuffix: string;
+  title: string;
+  description: string;
+  highlight: {
+    title: string;
+    description: string;
+    ratioLabel: string;
+  };
+  secondaryCtaLabel: string;
+};
+
+type HeroSectionProps = {
+  schoolName: string;
+  stats: HomeStat[];
+  teacherStudentRatio: string;
+  copy: HeroCopy;
+};
+
+export function HeroSection({ schoolName, stats, teacherStudentRatio, copy }: HeroSectionProps) {
+  return (
+    <AuroraBackground className="rounded-b-[2.5rem] border-b border-white/60 bg-gradient-to-br from-white via-secondary/10 to-primary/10">
+      <PageSection
+        padding="none"
+        containerClassName="relative grid gap-16 pb-24 pt-20 lg:grid-cols-[1.1fr,0.9fr] lg:items-center"
+      >
+        <div className="relative space-y-8">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/60 px-4 py-2 text-sm font-semibold text-secondary shadow-soft backdrop-blur-sm backdrop-saturate-150">
+            <span className="h-2.5 w-2.5 rounded-full bg-secondary" aria-hidden="true" />
+            {schoolName} • {copy.badgeSuffix}
+          </span>
+          <h1 className="text-balance text-4xl font-bold leading-tight text-text sm:text-5xl">{copy.title}</h1>
+          <p className="max-w-xl text-pretty text-lg text-text-muted sm:text-xl">{copy.description}</p>
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+            <CTAButton ctaKey="heroVisit" />
+            <Link href="/ppdb" className="btn-secondary w-full sm:w-auto">
+              {copy.secondaryCtaLabel}
+            </Link>
+          </div>
+          <div className="grid gap-6 pt-6 sm:grid-cols-2 md:grid-cols-3">
+            {stats.map((item) => (
+              <CardSurface key={item.label} tone="translucent" padding="lg" className="text-left">
+                <p className="text-3xl font-bold text-text">
+                  <AnimatedCounter value={item.value} />
+                </p>
+                <p className="mt-1 text-base text-text-muted">{item.label}</p>
+              </CardSurface>
+            ))}
+          </div>
+        </div>
+
+        <AnimateIn className="relative flex justify-center">
+          <div className="absolute -top-12 right-6 h-40 w-40 rounded-full bg-accent/30 blur-2xl" aria-hidden="true" />
+          <div className="absolute -bottom-6 left-2 h-36 w-36 rounded-full bg-secondary/25 blur-2xl md:-bottom-10" aria-hidden="true" />
+          <CardSurface
+            tone="translucent"
+            padding="xl"
+            className="relative w-full max-w-md space-y-5 rounded-[2.5rem] text-center"
+          >
+            <p className="text-lg font-semibold text-secondary">{copy.highlight.title}</p>
+            <p className="text-base leading-relaxed text-text-muted">{copy.highlight.description}</p>
+            <div className="flex items-center justify-center gap-3 text-base font-semibold text-text">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/15 text-lg" aria-hidden="true">
+                😊
+              </span>
+              {copy.highlight.ratioLabel} {teacherStudentRatio}
+            </div>
+          </CardSurface>
+        </AnimateIn>
+      </PageSection>
+    </AuroraBackground>
+  );
+}

--- a/components/home/sections/HighlightsSection.tsx
+++ b/components/home/sections/HighlightsSection.tsx
@@ -1,0 +1,48 @@
+import AnimateIn from "@/components/AnimateIn";
+import PageSection from "@/components/layout/PageSection";
+import SectionHeader from "@/components/layout/SectionHeader";
+import type { HomeHighlight } from "@/app/types/home";
+import { CardSurface } from "@/components/ui/CardSurface";
+
+type HighlightsCopy = {
+  eyebrow: string;
+  title: string;
+  description: string;
+};
+
+type HighlightsSectionProps = {
+  highlights: HomeHighlight[];
+  copy: HighlightsCopy;
+};
+
+export function HighlightsSection({ highlights, copy }: HighlightsSectionProps) {
+  return (
+    <PageSection
+      className="relative border-y border-white/50 bg-white/50 backdrop-blur-sm backdrop-saturate-150"
+      padding="tight"
+    >
+      <AnimateIn>
+        <SectionHeader
+          align="center"
+          eyebrow={copy.eyebrow}
+          eyebrowVariant="primary"
+          title={copy.title}
+          description={copy.description}
+        />
+      </AnimateIn>
+      <div className="mt-12 grid gap-6 md:grid-cols-3">
+        {highlights.map((item) => (
+          <AnimateIn key={item.title}>
+            <CardSurface tone="soft" padding="lg" className="h-full text-left">
+              <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/15 text-2xl" aria-hidden="true">
+                {item.icon}
+              </span>
+              <h3 className="mt-6 text-xl font-semibold text-text">{item.title}</h3>
+              <p className="mt-3 text-base leading-relaxed text-text-muted">{item.description}</p>
+            </CardSurface>
+          </AnimateIn>
+        ))}
+      </div>
+    </PageSection>
+  );
+}

--- a/components/home/sections/OnboardingSection.tsx
+++ b/components/home/sections/OnboardingSection.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+
+import CTAButton from "@/components/CTAButton";
+import AnimateIn from "@/components/AnimateIn";
+import PageSection from "@/components/layout/PageSection";
+import SectionHeader from "@/components/layout/SectionHeader";
+import TimelineSteps from "@/components/reactbits/TimelineSteps";
+import type { HomeOnboardingStep } from "@/app/types/home";
+
+export type OnboardingCopy = {
+  eyebrow: string;
+  title: string;
+  description: string;
+  primaryCtaLabel: string;
+};
+
+type OnboardingSectionProps = {
+  steps: readonly HomeOnboardingStep[];
+  copy: OnboardingCopy;
+};
+
+export function OnboardingSection({ steps, copy }: OnboardingSectionProps) {
+  return (
+    <PageSection
+      className="relative border-y border-white/50 bg-gradient-to-br from-primary/10 via-white to-secondary/10"
+      padding="tight"
+    >
+      <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+        <div className="absolute left-8 top-8 h-40 w-40 rounded-full bg-primary/20 blur-3xl" />
+        <div className="absolute right-12 bottom-12 h-48 w-48 rounded-full bg-secondary/20 blur-3xl" />
+      </div>
+      <AnimateIn className="relative">
+        <SectionHeader
+          align="center"
+          eyebrow={copy.eyebrow}
+          eyebrowVariant="primary"
+          title={copy.title}
+          description={copy.description}
+        />
+      </AnimateIn>
+      <TimelineSteps steps={steps} className="relative mt-12" />
+      <div className="relative mt-12 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-center">
+        <Link href="/ppdb" className="btn-primary w-full sm:w-auto">
+          {copy.primaryCtaLabel}
+        </Link>
+        <CTAButton ctaKey="visitSchedule" className="w-full sm:w-auto" />
+      </div>
+    </PageSection>
+  );
+}

--- a/components/home/sections/ProgramsSection.tsx
+++ b/components/home/sections/ProgramsSection.tsx
@@ -1,0 +1,61 @@
+import AnimateIn from "@/components/AnimateIn";
+import PageSection from "@/components/layout/PageSection";
+import SectionHeader from "@/components/layout/SectionHeader";
+import StickyScrollReveal from "@/components/reactbits/StickyScrollReveal";
+import type { HomeProgram } from "@/app/types/home";
+
+type ProgramsCopy = {
+  eyebrow: string;
+  title: string;
+  description: string;
+  preparationSteps: string[];
+  stickyReveal: {
+    eyebrow: string;
+    heading: string;
+    description: string;
+  };
+};
+
+type ProgramsSectionProps = {
+  programs: HomeProgram[];
+  copy: ProgramsCopy;
+};
+
+export function ProgramsSection({ programs, copy }: ProgramsSectionProps) {
+  return (
+    <PageSection id="program" padding="tight">
+      <AnimateIn className="max-w-3xl space-y-6">
+        <SectionHeader
+          eyebrow={copy.eyebrow}
+          eyebrowVariant="secondary"
+          title={copy.title}
+          description={copy.description}
+        />
+        <ul className="space-y-3 text-base text-text-muted">
+          {copy.preparationSteps.map((step, index) => (
+            <li key={step} className="flex items-start gap-3">
+              <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary" aria-hidden="true">
+                {index + 1}
+              </span>
+              {step}
+            </li>
+          ))}
+        </ul>
+      </AnimateIn>
+      <StickyScrollReveal
+        eyebrow={copy.stickyReveal.eyebrow}
+        heading={copy.stickyReveal.heading}
+        description={copy.stickyReveal.description}
+        items={programs.map((program, index) => ({
+          id: `${program.name}-${index}`,
+          title: program.name,
+          subtitle: program.age,
+          description: program.description,
+          highlights: program.points,
+          icon: "✨",
+        }))}
+        className="mt-12"
+      />
+    </PageSection>
+  );
+}

--- a/components/ui/CardSurface.tsx
+++ b/components/ui/CardSurface.tsx
@@ -1,0 +1,37 @@
+import type { ComponentPropsWithoutRef } from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+export const cardSurfaceVariants = cva(
+  "rounded-3xl border shadow-soft backdrop-saturate-150",
+  {
+    variants: {
+      tone: {
+        translucent: "border-white/60 bg-white/60 backdrop-blur-lg",
+        soft: "border-white/70 bg-white/70 backdrop-blur-xl",
+        gradient: "border-white/70 bg-gradient-to-br from-primary/10 via-white to-secondary/10 backdrop-blur-xl",
+        outline: "border-white/60 bg-transparent",
+      },
+      padding: {
+        none: "p-0",
+        sm: "p-4",
+        md: "p-6",
+        lg: "p-7",
+        xl: "p-8",
+      },
+    },
+    defaultVariants: {
+      tone: "translucent",
+      padding: "md",
+    },
+  },
+);
+
+export type CardSurfaceProps = ComponentPropsWithoutRef<"div"> &
+  VariantProps<typeof cardSurfaceVariants>;
+
+export function CardSurface({ className, tone, padding, ...props }: CardSurfaceProps) {
+  return <div className={cn(cardSurfaceVariants({ tone, padding }), className)} {...props} />;
+}

--- a/content/home.ts
+++ b/content/home.ts
@@ -5,10 +5,181 @@ import type {
   HomeFaq,
   HomeHighlight,
   HomeJourneyItem,
+  HomeOnboardingStep,
   HomeProgram,
   HomeStat,
   HomeTimelineMilestone,
+  HomeAgendaItem,
 } from "@/app/types/home";
+
+export const homeHero = {
+  badgeSuffix: "Kurikulum Merdeka PAUD",
+  title: "Awal Terbaik untuk Si Kecil: Belajar Sambil Ceria di Rumah Kedua Mereka",
+  description:
+    "Sebagai TK berpengalaman di Bantarsari, kami menggabungkan tradisi pengajaran yang hangat dengan Kurikulum Merdeka. Kami memastikan setiap anak mendapat perhatian personal dalam lingkungan yang aman, sehingga mereka tumbuh percaya diri, kreatif, dan siap untuk jenjang sekolah berikutnya.",
+  highlight: {
+    title: "Belajar aktif & penuh perhatian",
+    description:
+      "Kelas kecil dengan guru pendamping personal membantu anak cepat nyaman, bereksplorasi, dan siap melanjutkan ke jenjang berikutnya.",
+    ratioLabel: "Rasio guru : anak",
+  },
+  secondaryCtaLabel: "Info PPDB",
+};
+
+export const homeOnboardingCopy = {
+  eyebrow: "Mulai dari Sini",
+  title: "Alur singkat bergabung bersama TK Kartikasari",
+  description:
+    "Ikuti empat langkah ringkas ini untuk mengenal sekolah, menyiapkan berkas, dan memastikan kuota sebelum periode pendaftaran tatap muka dibuka.",
+  primaryCtaLabel: "Info PPDB 2025/2026",
+  steps: [
+    {
+      key: "routine",
+      href: "#pengalaman",
+      icon: "🧭",
+      title: "Jelajahi Rutinitas & Lingkungan",
+      description:
+        "Kenali agenda harian, suasana kelas, dan cara kami mendampingi anak agar cepat nyaman.",
+      linkLabel: "Lihat pengalaman harian",
+    },
+    {
+      key: "cost",
+      href: "/biaya",
+      icon: "💡",
+      title: "Hitung Investasi Pendidikan",
+      description:
+        "Pelajari struktur biaya, jadwal pembayaran, dan opsi keringanan agar rencana keluarga tetap nyaman.",
+      linkLabel: "Buka rincian biaya",
+    },
+    {
+      key: "documents",
+      href: "/ppdb#requirements",
+      icon: "🗂️",
+      title: "Lengkapi Dokumen Awal",
+      description:
+        "Siapkan akta kelahiran, KK, dan identitas orang tua agar proses administrasi berjalan mulus.",
+      linkLabel: "Lihat daftar dokumen",
+    },
+    {
+      key: "apply",
+      href: "/kontak",
+      icon: "📍",
+      title: "Konfirmasi Kuota & Jadwal",
+      description:
+        "Hubungi admin TK Kartikasari untuk mengetahui status kuota terbaru, daftar tunggu, dan jadwal pembaruan PPDB.",
+      linkLabel: "Hubungi admin sekarang",
+    },
+  ] satisfies HomeOnboardingStep[],
+};
+
+export const homeHighlightsCopy = {
+  eyebrow: "Mengapa orang tua mempercayakan anaknya",
+  title: "Tiga janji utama kami untuk ketenangan Ayah & Bunda",
+  description:
+    "Komitmen kami adalah menciptakan lingkungan belajar yang aman secara legal, nyaman untuk anak, dan berakar pada nilai-nilai keindonesiaan.",
+};
+
+export const homeCredentialsCopy = {
+  eyebrow: "Bukti Kepercayaan Anda",
+  title: "Kredensial Resmi dan Perjalanan Panjang yang Teruji",
+  description:
+    "Seluruh informasi sekolah tersimpan di basis data Kemendikbudristek dan diperkuat oleh sejarah layanan kami untuk keluarga Bantarsari.",
+  legalTitle: "Legalitas & Info Resmi",
+  timelineTitle: "Jejak Langkah Kami",
+};
+
+export const homeCurriculumCopy = {
+  eyebrow: "Filosofi Pendidikan Kami",
+  title: "Tiga Pilar Kami dalam Membentuk Karakter Anak",
+  description:
+    "Kami fokus pada tiga area utama untuk memastikan anak tidak hanya pintar, tetapi juga tumbuh menjadi pribadi yang baik, bangga pada budayanya, dan siap untuk belajar lebih lanjut.",
+};
+
+export const homeProgramsCopy = {
+  eyebrow: "Program Kurikulum Merdeka",
+  title: "Jalur Belajar yang Disesuaikan untuk Setiap Anak",
+  description:
+    "Guru inti dan guru pendamping berkolaborasi untuk menyeimbangkan pengembangan karakter, kemampuan dasar, dan kegembiraan bermain melalui projek-projek yang relevan dengan dunia anak.",
+  preparationSteps: [
+    "Observasi minat, gaya belajar, serta diskusi orang tua untuk menentukan kebutuhan utama anak.",
+    "Perumusan tujuan pembelajaran Kurikulum Merdeka dan strategi diferensiasi setiap awal tema.",
+    "Pameran karya, refleksi projek P5, dan laporan portofolio terstruktur di akhir tema.",
+  ],
+  stickyReveal: {
+    eyebrow: "Sorot Program",
+    heading: "Pengalaman belajar yang menyatu dari playgroup hingga TK B",
+    description:
+      "Setiap kelas dirancang dengan ritme yang lembut, memadukan eksplorasi terstruktur dan bermain bebas supaya anak belajar tanpa kehilangan rasa aman.",
+  },
+};
+
+export const homeExperienceCopy = {
+  eyebrow: "Aktivitas Harian",
+  title: "Transisi Lembut yang Menjaga Antusiasme Anak",
+  description:
+    "Rangkaian kegiatan mengikuti struktur Kurikulum Merdeka PAUD: mulai dari pembiasaan nilai, eksplorasi, hingga refleksi dan asesmen autentik.",
+  parentCollab: {
+    title: "Kolaborasi dengan Orang Tua",
+    description:
+      "Orang tua menerima ringkasan harian, refleksi projek P5, dan rekomendasi penguatan karakter untuk diterapkan di rumah.",
+  },
+};
+
+export const homeDailyAgenda = {
+  header: {
+    title: "Agenda Kurikulum Merdeka",
+    badge: "Projek Profil Pelajar Pancasila",
+  },
+  items: [
+    { time: "07.00", description: "Penyambutan hangat, doa, dan pemetaan emosi anak." },
+    { time: "08.30", description: "Diskusi nilai Pancasila dan eksplorasi budaya lokal." },
+    { time: "10.00", description: "Sentra pilihan: STEAM, literasi, seni, atau role play terarah." },
+  ] satisfies HomeAgendaItem[],
+  info: {
+    title: "Lingkungan aman & terdata resmi",
+    description:
+      "Terdaftar dengan NPSN {{npsn}}, area 440 m² terpantau, dan peralatan ramah anak untuk belajar yang nyaman.",
+    ratioLabel: "Rasio guru : anak",
+    defaultNpsn: "20351273",
+  },
+  focusCards: [
+    {
+      title: "Fokus Harian",
+      description: "Nilai agama & budi pekerti, jati diri, serta kecakapan literasi sesuai fase fondasi.",
+    },
+    {
+      title: "Asesmen Autentik",
+      description: "Jurnal perkembangan, dokumentasi karya, dan umpan balik personal setiap pekan.",
+    },
+  ],
+};
+
+export const homeBlogCopy = {
+  eyebrow: "Blog & Berita",
+  title: "Tips Parenting dan Kegiatan Sekolah Terbaru",
+  description:
+    "Ikuti artikel terbaru dari kami untuk mendapatkan wawasan seputar dunia pendidikan anak usia dini dan melihat keseruan kegiatan di TK Kartikasari.",
+  emptyTitle: "Belum ada cerita terbaru",
+  emptyDescription:
+    "Tim kami sedang mempersiapkan artikel yang bisa membantu Ayah dan Bunda. Sementara itu, silakan jelajahi halaman lain atau hubungi kami untuk informasi langsung.",
+  emptyPrimaryCta: "Lihat program belajar",
+  emptySecondaryCta: "Hubungi kami",
+};
+
+export const homeFaqCopy = {
+  eyebrow: "Sering Ditanyakan",
+  title: "Informasi Penting Seputar Pendaftaran",
+  description:
+    "Jika ada pertanyaan lain, kami dengan senang hati menjawab melalui WhatsApp ataupun ketika Anda berkunjung langsung.",
+};
+
+export const homeFinalCtaCopy = {
+  eyebrow: "Siap Bergabung",
+  title: "Lihat Langsung Bagaimana Anak-Anak Belajar dengan Gembira",
+  description:
+    "Kami mengundang Anda untuk merasakan sendiri suasana hangat di kelas kami. Lihat sentra belajar yang interaktif dan temukan bagaimana projek seru kami menumbuhkan kreativitas serta rasa percaya diri anak.",
+  secondaryCtaLabel: "Lihat Program Kembali",
+};
 
 export const homeHeroDescription =
   "Membantu anak tumbuh menjadi pribadi yang ceria dan berkarakter Pancasila. Caranya? Lewat pendampingan personal, kegiatan yang sesuai minat anak, dan projek seru yang membangun kemampuan anak sesuai standar pendidikan nasional.";

--- a/lib/home.ts
+++ b/lib/home.ts
@@ -1,0 +1,84 @@
+import type {
+  HomeCredential,
+  HomeJourneyItem,
+  HomeOnboardingStep,
+  HomeStat,
+} from "@/app/types/home";
+import { homeJourney, homeOnboardingCopy } from "@/content/home";
+
+export type OnboardingStepOverrides = {
+  journey?: HomeJourneyItem[];
+  biayaDescription?: string;
+  documentDescription?: string;
+  metaDescription?: string;
+};
+
+export function buildOnboardingSteps({
+  journey,
+  biayaDescription,
+  documentDescription,
+  metaDescription,
+}: OnboardingStepOverrides): readonly HomeOnboardingStep[] {
+  const steps = homeOnboardingCopy.steps;
+
+  const journeyDescription = journey?.[0]?.description ?? homeJourney[0]?.description;
+
+  return steps.map((step) => {
+    switch (step.key) {
+      case "routine":
+        return {
+          ...step,
+          description: journeyDescription ?? step.description,
+        };
+      case "cost":
+        return {
+          ...step,
+          description: biayaDescription ?? step.description,
+        };
+      case "documents":
+        return {
+          ...step,
+          description: documentDescription ?? step.description,
+        };
+      case "apply":
+        return {
+          ...step,
+          description: metaDescription ?? step.description,
+        };
+      default:
+        return step;
+    }
+  });
+}
+
+export function extractTeacherStudentRatio(stats: HomeStat[], fallback = "1 : 8"): string {
+  return (
+    stats.find((item) => item.label.toLowerCase().includes("rasio"))?.value?.trim() ?? fallback
+  );
+}
+
+export function extractCredentialValue(
+  credentials: HomeCredential[],
+  label: string,
+): string | undefined {
+  return credentials.find((item) => item.label.toLowerCase() === label.toLowerCase())?.value;
+}
+
+export function formatBlogDescription(rawBody: string | undefined): string {
+  if (!rawBody) {
+    return "";
+  }
+
+  const normalizedBody = rawBody
+    .replace(/[#*_`>\-]/g, "")
+    .replace(/\[(.*?)\]\(.*?\)/g, "$1")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (normalizedBody.length <= 160) {
+    return normalizedBody;
+  }
+
+  return `${normalizedBody.slice(0, 157)}...`;
+}


### PR DESCRIPTION
## Summary
- break down HomePageContent into focused section components and share logic via new helpers
- introduce CardSurface utility to standardize translucent card styling across the homepage and agenda
- move homepage copy and agenda data into content/home.ts for easier maintenance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcaa67b6e4832f8e880a5db4d4e14b