### PR TITLE
Ensure CTA arrows use shared icon component

### DIFF
--- a/app/biaya/page.tsx
+++ b/app/biaya/page.tsx
@@ -2,7 +2,7 @@ import PageHeader from '@/components/layout/PageHeader';
 import PageSection from '@/components/layout/PageSection';
 import SectionHeader from '@/components/layout/SectionHeader';
 import BiayaClientComponent from './BiayaClientComponent';
-import { CheckCircle, InfoCircle, Telephone } from 'react-bootstrap-icons';
+import { ArrowRight, CheckCircle, InfoCircle, Telephone } from 'react-bootstrap-icons';
 import AnimateIn from '@/components/AnimateIn';
 import { getBiayaPageData } from '@/lib/sanity.queries';
 import { createPageMetadata } from '@/lib/metadata';
@@ -87,8 +87,12 @@ export default async function BiayaPage() {
           <div className="mt-12 rounded-2xl border border-primary/30 bg-primary/5 p-6 text-center">
             <p className="text-base text-text">
               Ingin membayar dengan lebih ringan?{' '}
-              <a href="#dukungan-finansial" className="font-semibold text-primary underline-offset-4 hover:underline">
-                Lihat Opsi Cicilan dan Diskon Kami di Bawah →
+              <a
+                href="#dukungan-finansial"
+                className="inline-flex items-center gap-1 font-semibold text-primary underline-offset-4 hover:underline"
+              >
+                <span>Lihat Opsi Cicilan dan Diskon Kami di Bawah</span>
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
               </a>
             </p>
           </div>
@@ -175,7 +179,13 @@ export default async function BiayaPage() {
                     <h4 className="text-lg font-semibold text-text">Keringanan Biaya/Beasiswa (Untuk Kasus Khusus)</h4>
                     <p className="mt-2 text-sm text-text-muted">
                       Kami percaya pendidikan harus dapat diakses. Jika Anda menghadapi kendala finansial, kami memiliki skema bantuan khusus.{' '}
-                      <a href="/kontak" className="font-semibold text-primary underline-offset-4 hover:underline">Pelajari kriteria dan cara pengajuan →</a>
+                      <a
+                        href="/kontak"
+                        className="inline-flex items-center gap-1 font-semibold text-primary underline-offset-4 hover:underline"
+                      >
+                        <span>Pelajari kriteria dan cara pengajuan</span>
+                        <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                      </a>
                     </p>
                   </div>
                 </div>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -86,7 +86,7 @@ function BlogCard({ post }: { post: Post }) {
           <h3 className="mt-2 text-lg font-semibold text-text">{post.title}</h3>
           <p className="mt-2 flex-grow text-sm text-text-muted">{description}</p>
           <div className="mt-4 flex items-center text-sm font-semibold text-primary">
-            Baca selengkapnya <ArrowRight className="ml-1 h-4 w-4" />
+            Baca selengkapnya <ArrowRight className="ml-1 h-4 w-4" aria-hidden="true" />
           </div>
         </div>
       </div>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -18,8 +18,8 @@ export default function NotFound() {
         </p>
         <div className="mt-10 flex flex-col gap-4 sm:flex-row">
           <Button asChild className="sm:w-auto" fullWidth>
-            <Link href="/">
-              Kembali ke beranda
+            <Link href="/" className="inline-flex items-center gap-2">
+              <span>Kembali ke beranda</span>
               <ArrowRight className="h-4 w-4" aria-hidden="true" />
             </Link>
           </Button>

--- a/components/home/sections/BlogSection.tsx
+++ b/components/home/sections/BlogSection.tsx
@@ -74,7 +74,7 @@ export function BlogSection({ posts, copy }: BlogSectionProps) {
                       <h3 className="mt-2 text-lg font-semibold text-text">{post.title}</h3>
                       <p className="mt-2 flex-grow text-sm text-text-muted">{description}</p>
                       <div className="mt-4 flex items-center text-sm font-semibold text-primary transition-transform group-hover:translate-x-1">
-                        Baca selengkapnya <ArrowRight className="ml-1 h-4 w-4" />
+                        Baca selengkapnya <ArrowRight className="ml-1 h-4 w-4" aria-hidden="true" />
                       </div>
                     </div>
                   </article>

--- a/components/reactbits/TimelineSteps.tsx
+++ b/components/reactbits/TimelineSteps.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { motion } from "framer-motion";
+import { ArrowRight } from "react-bootstrap-icons";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/Button";
@@ -62,7 +63,7 @@ export default function TimelineSteps({ steps, className }: TimelineStepsProps) 
             <Button asChild variant="outline" size="sm">
               <Link href={step.href} className="inline-flex items-center gap-2">
                 <span>{step.linkLabel}</span>
-                <span aria-hidden="true">→</span>
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
               </Link>
             </Button>
             <Badge tone="secondary" size="sm" className="uppercase text-secondary/80">

--- a/components/tentang/AboutPageContent.tsx
+++ b/components/tentang/AboutPageContent.tsx
@@ -6,6 +6,7 @@ import CTAButton from "@/components/CTAButton";
 import PageHeader from "@/components/layout/PageHeader";
 import PageSection from "@/components/layout/PageSection";
 import {
+  ArrowRight,
   ClockHistory,
   EnvelopeHeart,
   GeoAlt,
@@ -117,8 +118,9 @@ export default function AboutPageContent({
           </div>
           <div className="flex justify-center">
             <Button asChild variant="secondary" size="sm" className="rounded-full px-6 py-3">
-              <Link href="/program" className="gap-2">
-                Pelajari Program Kami →
+              <Link href="/program" className="inline-flex items-center gap-2">
+                <span>Pelajari Program Kami</span>
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
               </Link>
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- ensure the not-found primary button uses the shared ArrowRight icon with proper inline layout
- add aria-hidden to remaining CTA ArrowRight icons in the blog listing and card components for accessibility compliance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcde64cda8832f8e25b28b585ea6dc