### PR TITLE
Improve mobile nav performance by removing framer-motion

### DIFF
--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -1,78 +1,12 @@
+"use client";
 
-'use client';
+import { type TransitionEvent, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ChevronDown } from "react-bootstrap-icons";
 
-import { useState } from 'react';
-import { usePathname } from 'next/navigation';
-import Link from 'next/link';
-import { AnimatePresence, motion, Variants } from 'framer-motion';
-import { ChevronDown } from 'react-bootstrap-icons';
-
-import { useSiteData } from '@/app/providers/SiteDataProvider';
-
-const smoothEase = [0.4, 0, 0.2, 1] as const;
-
-// VARIANTS FOR THE MAIN MENU CONTAINER (BACKGROUND)
-const menuVariants: Variants = {
-  hidden: {
-    opacity: 0,
-    y: '-100%',
-  },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.55,
-      ease: smoothEase,
-      // Stagger the animation of children (nav items) when the menu enters
-      delayChildren: 0.15, // Start animating children after a brief delay
-      staggerChildren: 0.08, // Stagger each child's animation
-    },
-  },
-  exit: {
-    opacity: 0,
-    y: '-100%',
-    transition: {
-      duration: 0.45,
-      ease: [0.4, 0, 1, 1] as const,
-      // IMPORTANT: Wait for children to finish their exit animation before this one starts
-      when: 'afterChildren',
-      // Stagger the exit of children, in reverse order
-      staggerChildren: 0.06,
-      staggerDirection: -1,
-    },
-  },
-};
-
-// VARIANTS FOR EACH NAVIGATION ITEM (LINK OR ACCORDION)
-const navItemVariants: Variants = {
-  hidden: {
-    opacity: 0,
-    y: 20, // Start slightly lower
-  },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.45,
-      ease: smoothEase,
-    },
-  },
-  exit: {
-    opacity: 0,
-    y: 20, // Move down on exit
-    transition: {
-      duration: 0.3, // Items fade out smoothly
-      ease: 'easeIn',
-    },
-  },
-};
-
-// VARIANTS FOR THE ACCORDION CONTENT (SUB-MENU)
-const accordionContentVariants: Variants = {
-  hidden: { opacity: 0, height: 0, transition: { duration: 0.35, ease: smoothEase } },
-  visible: { opacity: 1, height: 'auto', transition: { duration: 0.45, ease: smoothEase } },
-  exit: { opacity: 0, height: 0, transition: { duration: 0.35, ease: smoothEase } },
-};
+import { useSiteData } from "@/app/providers/SiteDataProvider";
+import { cn } from "@/lib/utils";
 
 interface MobileMenuProps {
   isOpen: boolean;
@@ -81,110 +15,144 @@ interface MobileMenuProps {
 
 export default function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
   const pathname = usePathname();
-  const [openAccordion, setOpenAccordion] = useState<string | null>(null);
   const { navigation } = useSiteData();
+  const [openAccordion, setOpenAccordion] = useState<string | null>(null);
+  const [shouldRender, setShouldRender] = useState(isOpen);
 
-  const toggleAccordion = (label: string) => {
-    setOpenAccordion(openAccordion === label ? null : label);
+  useEffect(() => {
+    if (isOpen) {
+      setShouldRender(true);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setOpenAccordion(null);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  const handleTransitionEnd = (event: TransitionEvent<HTMLDivElement>) => {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+
+    if (!isOpen) {
+      setShouldRender(false);
+    }
   };
 
+  const toggleAccordion = (label: string) => {
+    setOpenAccordion((current) => (current === label ? null : label));
+  };
+
+  const items = useMemo(() => navigation, [navigation]);
+
+  if (!shouldRender) {
+    return null;
+  }
+
   return (
-    <AnimatePresence mode="wait">
-      {isOpen && (
-        <motion.div
-          key="mobile-nav"
-          id="mobile-nav"
-          className="fixed inset-0 z-40 overflow-y-auto bg-surface pt-24 pb-12"
-          variants={menuVariants}
-          initial="hidden"
-          animate="visible"
-          exit="exit"
-        >
-          <nav className="flex flex-col gap-1 px-4 text-xl font-medium text-text">
-            {navigation.map((item, index) => {
-              if ('children' in item) {
-                const isAccordionOpen = openAccordion === item.label;
-                return (
-                  <motion.div
-                    key={item.label}
-                    variants={navItemVariants} // Use navItemVariants for each item
-                  >
-                    <button
-                      onClick={() => toggleAccordion(item.label)}
-                      aria-expanded={isAccordionOpen}
-                      className="flex w-full items-center justify-between rounded-full px-4 py-2 text-left transition-colors duration-200 hover:bg-surfaceAlt focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40"
-                    >
-                      <span className="font-semibold text-text">{item.label}</span>
-                      <ChevronDown
-                        className={`h-5 w-5 text-text-muted transition-transform duration-300 ${isAccordionOpen ? 'rotate-180' : ''}`}
-                        aria-hidden="true"
-                      />
-                    </button>
-                    <AnimatePresence>
-                      {isAccordionOpen && (
-                        <motion.div
-                          key={`${item.label}-content`}
-                          variants={accordionContentVariants}
-                          initial="hidden"
-                          animate="visible"
-                          exit="hidden"
-                          className="overflow-hidden pl-4"
-                        >
-                          <div className="mt-2 flex flex-col gap-1 border-l border-border py-2 pl-4">
-                            {item.children.map((child) => {
-                              const isActive = pathname === child.href || pathname.startsWith(`${child.href}/`);
-                              return (
-                                <Link
-                                  key={child.href}
-                                  href={child.href}
-                                  onClick={onClose}
-                                  aria-current={isActive ? 'page' : undefined}
-                                  className={`block rounded-full px-5 py-2 text-base transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40 ${
-                                    isActive
-                                      ? 'text-pink-500'
-                                      : 'text-text-muted hover:bg-surfaceAlt hover:text-text'
-                                  }`}
-                                >
-                                  {child.label}
-                                </Link>
-                              );
-                            })}
-                          </div>
-                        </motion.div>
-                      )}
-                    </AnimatePresence>
-                  </motion.div>
-                );
-              }
-
-              if (!('href' in item) || !item.href) {
-                return null;
-              }
-
-              const isActive = item.href === '/' ? pathname === '/' : pathname.startsWith(item.href);
-              return (
-                <motion.div
-                  key={item.href}
-                  variants={navItemVariants} // Use navItemVariants for each item
-                >
-                  <Link
-                    href={item.href}
-                    onClick={onClose}
-                    aria-current={isActive ? 'page' : undefined}
-                    className={`block rounded-full px-4 py-2 font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40 ${
-                      isActive
-                        ? 'font-semibold text-pink-500 bg-surfaceAlt'
-                        : 'text-text hover:bg-surfaceAlt'
-                    }`}
-                  >
-                    {item.label}
-                  </Link>
-                </motion.div>
-              );
-            })}
-          </nav>
-        </motion.div>
+    <div
+      id="mobile-nav"
+      role="dialog"
+      aria-modal="true"
+      aria-hidden={!isOpen}
+      className={cn(
+        "fixed inset-0 z-40 overflow-y-auto bg-surface pt-24 pb-12 transition-opacity duration-200 ease-out",
+        isOpen ? "opacity-100" : "pointer-events-none opacity-0",
       )}
-    </AnimatePresence>
+      onTransitionEnd={handleTransitionEnd}
+    >
+      <nav
+        className={cn(
+          "flex transform flex-col gap-1 px-4 text-xl font-medium text-text transition-transform duration-300 ease-out",
+          isOpen ? "translate-y-0" : "-translate-y-3",
+        )}
+      >
+        {items.map((item) => {
+          if ("children" in item) {
+            const isAccordionOpen = openAccordion === item.label;
+
+            return (
+              <div key={item.label}>
+                <button
+                  onClick={() => toggleAccordion(item.label)}
+                  aria-expanded={isAccordionOpen}
+                  className="flex w-full items-center justify-between rounded-full px-4 py-2 text-left transition-colors duration-150 hover:bg-surfaceAlt focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40"
+                >
+                  <span className="font-semibold text-text">{item.label}</span>
+                  <ChevronDown
+                    className={cn(
+                      "h-5 w-5 text-text-muted transition-transform duration-200",
+                      isAccordionOpen ? "rotate-180" : "rotate-0",
+                    )}
+                    aria-hidden="true"
+                  />
+                </button>
+                {isAccordionOpen && (
+                  <div className="mt-2 flex flex-col gap-1 border-l border-border py-2 pl-4">
+                    {item.children.map((child) => {
+                      const isActive = pathname === child.href || pathname.startsWith(`${child.href}/`);
+                      return (
+                        <Link
+                          key={child.href}
+                          href={child.href}
+                          onClick={onClose}
+                          aria-current={isActive ? "page" : undefined}
+                          className={cn(
+                            "block rounded-full px-5 py-2 text-base transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40",
+                            isActive
+                              ? "text-pink-500"
+                              : "text-text-muted hover:bg-surfaceAlt hover:text-text",
+                          )}
+                        >
+                          {child.label}
+                        </Link>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            );
+          }
+
+          if (!("href" in item) || !item.href) {
+            return null;
+          }
+
+          const isActive = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              onClick={onClose}
+              aria-current={isActive ? "page" : undefined}
+              className={cn(
+                "block rounded-full px-4 py-2 font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40",
+                isActive ? "bg-surfaceAlt font-semibold text-pink-500" : "text-text hover:bg-surfaceAlt",
+              )}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </div>
   );
 }

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -1,6 +1,6 @@
-'use client';
+"use client";
 
-import { motion } from 'framer-motion';
+import { cn } from "@/lib/utils";
 
 interface MobileNavProps {
   isOpen: boolean;
@@ -10,7 +10,7 @@ interface MobileNavProps {
 export default function MobileNav({ isOpen, onToggle }: MobileNavProps) {
   return (
     <div className="relative z-50 lg:hidden">
-      <motion.button
+      <button
         type="button"
         onClick={onToggle}
         aria-expanded={isOpen}
@@ -19,18 +19,22 @@ export default function MobileNav({ isOpen, onToggle }: MobileNavProps) {
       >
         <span className="sr-only">Toggle navigation</span>
         <span className="relative block h-5 w-6" aria-hidden>
-          <motion.span
-            className="absolute left-0 top-1 h-0.5 w-full rounded bg-current"
-            animate={isOpen ? { rotate: 45, y: 5 } : { rotate: 0, y: 0 }}
-            transition={{ duration: 0.32, ease: [0.4, 0, 0.2, 1] }}
+          <span
+            className={cn(
+              "absolute left-0 block h-0.5 w-full rounded bg-current transition-transform duration-200 ease-out",
+              isOpen ? "translate-y-2.5 rotate-45" : "translate-y-0 rotate-0",
+            )}
+            style={{ top: "6px" }}
           />
-          <motion.span
-            className="absolute left-0 bottom-1 h-0.5 w-full rounded bg-current"
-            animate={isOpen ? { rotate: -45, y: -5 } : { rotate: 0, y: 0 }}
-            transition={{ duration: 0.32, ease: [0.4, 0, 0.2, 1] }}
+          <span
+            className={cn(
+              "absolute left-0 block h-0.5 w-full rounded bg-current transition-transform duration-200 ease-out",
+              isOpen ? "-translate-y-2.5 -rotate-45" : "translate-y-0 rotate-0",
+            )}
+            style={{ bottom: "6px" }}
           />
         </span>
-      </motion.button>
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the framer-motion powered mobile navigation button and menu with lighter CSS transitions
- gate rendering of the mobile menu and handle escape key presses to avoid unnecessary work when the menu is closed

## Testing
- npm run lint *(passes with existing warnings about <img> usage and an unrelated Sanity schema export)*

------
https://chatgpt.com/codex/tasks/task_e_68dce9300394832f939e6781cb9516fa