### PR TITLE
Fix testimonial marquee overflow clipping shadows

### DIFF
--- a/components/TestimonialList.tsx
+++ b/components/TestimonialList.tsx
@@ -70,7 +70,7 @@ export default function TestimonialList({ testimonials }: TestimonialListProps) 
             />
           </m.div>
 
-          <div className="mt-14 overflow-hidden">
+          <div className="mt-14 overflow-x-hidden">
             <div
               className="flex w-max gap-6 animate-marquee"
               style={marqueeStyle}


### PR DESCRIPTION
## Summary
- restrict the testimonial marquee container to horizontal overflow hiding so shadows remain visible vertically

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dced822768832fab2777d2c31c996e