### PR TITLE
Fix teacher roster rendering on about page

### DIFF
--- a/components/tentang/AboutPageContent.tsx
+++ b/components/tentang/AboutPageContent.tsx
@@ -258,7 +258,7 @@ export default function AboutPageContent({
               emosi, imajinasi, dan rasa ingin tahu agar setiap hari sekolah terasa hangat dan bermakna.
             </p>
           </div>
-          <TeacherList teachers={teachers} />
+          <TeacherList teachers={teachers} headmasterName={siteSettings.headmaster} />
         </AnimateIn>
       </PageSection>
 

--- a/components/tentang/TeacherList.tsx
+++ b/components/tentang/TeacherList.tsx
@@ -1,4 +1,5 @@
 
+import Image from "next/image";
 import { m } from "framer-motion";
 import { Person, PersonBadge } from "react-bootstrap-icons";
 import type { TeacherProfile } from "@/lib/types/site";
@@ -26,11 +27,91 @@ const itemVariants = {
 
 interface TeacherListProps {
   teachers: TeacherProfile[];
+  headmasterName?: string;
 }
 
-export default function TeacherList({ teachers }: TeacherListProps) {
-  const headmaster = teachers.find((t) => t.position === "Kepala Sekolah");
-  const otherTeachers = teachers.filter((t) => t.position !== "Kepala Sekolah");
+function TeacherAvatar({
+  name,
+  imageUrl,
+  icon: Icon,
+  size,
+  variant = "primary",
+}: {
+  name: string;
+  imageUrl?: string | null;
+  icon: typeof Person | typeof PersonBadge;
+  size: "lg" | "md";
+  variant?: "primary" | "neutral";
+}) {
+  const dimension = size === "lg" ? 192 : 160;
+  const backgroundClass =
+    variant === "primary"
+      ? "bg-secondary/10 text-secondary shadow-lg"
+      : "bg-gray-200/60 text-gray-500 shadow-md";
+
+  return (
+    <div
+      className={`relative mx-auto mb-4 flex items-center justify-center overflow-hidden rounded-full ${backgroundClass}`}
+      style={{ height: dimension, width: dimension }}
+    >
+      {imageUrl ? (
+        <Image
+          src={imageUrl}
+          alt={`Foto ${name}`}
+          fill
+          className="object-cover"
+          sizes="(max-width: 768px) 160px, 192px"
+        />
+      ) : (
+        <Icon className={size === "lg" ? "h-24 w-24" : "h-20 w-20"} />
+      )}
+    </div>
+  );
+}
+
+export default function TeacherList({ teachers, headmasterName }: TeacherListProps) {
+  const normalizedTeachers = Array.isArray(teachers) ? teachers : [];
+  const headmasterCandidate = normalizedTeachers.find((teacher) => {
+    if (teacher.isHeadmaster) {
+      return true;
+    }
+
+    return teacher.position.toLowerCase().includes("kepala sekolah");
+  });
+
+  const fallbackHeadmasterName = headmasterName?.trim().toLowerCase();
+
+  const headmaster =
+    headmasterCandidate ??
+    (headmasterName
+      ? {
+          name: headmasterName,
+          position: "Kepala Sekolah",
+          description: "Informasi kepala sekolah dapat diperbarui melalui Sanity Studio.",
+          impactStatement: null,
+          imageUrl: null,
+          isHeadmaster: true,
+        }
+      : undefined);
+
+  const otherTeachers = headmasterCandidate
+    ? normalizedTeachers.filter((teacher) => teacher !== headmasterCandidate)
+    : normalizedTeachers.filter((teacher) =>
+        fallbackHeadmasterName ? teacher.name.trim().toLowerCase() !== fallbackHeadmasterName : true,
+      );
+
+  if (!headmaster && otherTeachers.length === 0) {
+    return (
+      <m.p
+        initial={{ opacity: 0 }}
+        whileInView={{ opacity: 1 }}
+        viewport={{ once: true, amount: 0.3 }}
+        className="text-base text-text-muted"
+      >
+        Data guru belum tersedia. Silakan tambahkan profil melalui Sanity Studio untuk menampilkannya di halaman ini.
+      </m.p>
+    );
+  }
 
   return (
     <div className="space-y-12">
@@ -43,12 +124,12 @@ export default function TeacherList({ teachers }: TeacherListProps) {
           transition={{ duration: 0.6, ease: "easeOut" }}
           className="mx-auto max-w-sm text-center"
         >
-          <div className="relative mx-auto mb-4 flex h-48 w-48 items-center justify-center overflow-hidden rounded-full bg-secondary/10 text-secondary shadow-lg">
-            <PersonBadge className="h-24 w-24" />
-          </div>
+          <TeacherAvatar name={headmaster.name} imageUrl={headmaster.imageUrl} icon={PersonBadge} size="lg" />
           <h3 className="text-2xl font-semibold text-text">{headmaster.name}</h3>
           <p className="text-base text-secondary">{headmaster.position}</p>
-          <p className="mt-2 text-base text-text-muted">{headmaster.description}</p>
+          {headmaster.description ? (
+            <p className="mt-2 text-base text-text-muted">{headmaster.description}</p>
+          ) : null}
           {headmaster.impactStatement ? (
             <p className="mt-3 text-sm font-semibold text-secondary/80">
               {headmaster.impactStatement}
@@ -58,27 +139,35 @@ export default function TeacherList({ teachers }: TeacherListProps) {
       )}
 
       {/* Other Teachers Section */}
-      <m.div
-        variants={containerVariants}
-        initial="hidden"
-        whileInView="visible"
-        viewport={{ once: true, amount: 0.1 }}
-        className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3"
-      >
-        {otherTeachers.map((teacher, index) => (
-          <m.div key={index} variants={itemVariants} className="text-center">
-            <div className="relative mx-auto mb-4 flex h-40 w-40 items-center justify-center overflow-hidden rounded-full bg-gray-200/60 text-gray-500 shadow-md">
-              <Person className="h-20 w-20" />
-            </div>
-            <h3 className="text-xl font-semibold text-text">{teacher.name}</h3>
-            <p className="text-sm text-secondary">{teacher.position}</p>
-            <p className="mt-2 text-sm text-text-muted">{teacher.description}</p>
-            {teacher.impactStatement ? (
-              <p className="mt-3 text-sm font-semibold text-secondary/80">{teacher.impactStatement}</p>
-            ) : null}
-          </m.div>
-        ))}
-      </m.div>
+      {otherTeachers.length > 0 ? (
+        <m.div
+          variants={containerVariants}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.1 }}
+          className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3"
+        >
+          {otherTeachers.map((teacher, index) => (
+            <m.div key={index} variants={itemVariants} className="text-center">
+              <TeacherAvatar
+                name={teacher.name}
+                imageUrl={teacher.imageUrl}
+                icon={Person}
+                size="md"
+                variant="neutral"
+              />
+              <h3 className="text-xl font-semibold text-text">{teacher.name}</h3>
+              <p className="text-sm text-secondary">{teacher.position}</p>
+              {teacher.description ? (
+                <p className="mt-2 text-sm text-text-muted">{teacher.description}</p>
+              ) : null}
+              {teacher.impactStatement ? (
+                <p className="mt-3 text-sm font-semibold text-secondary/80">{teacher.impactStatement}</p>
+              ) : null}
+            </m.div>
+          ))}
+        </m.div>
+      ) : null}
     </div>
   );
 }

--- a/content/teachers.ts
+++ b/content/teachers.ts
@@ -3,6 +3,7 @@ export const teachers = [
   {
     name: "Bu Mintarsih",
     position: "Kepala Sekolah",
+    isHeadmaster: true,
     imageUrl: "/images/teachers/teacher-1.jpg",
     description:
       "Berdedikasi memastikan setiap aspek pendidikan selaras dengan visi sekolah. Beliau menciptakan lingkungan belajar yang aman, berkarakter, dan mendukung pertumbuhan individual setiap anak.",

--- a/lib/fallback-content.ts
+++ b/lib/fallback-content.ts
@@ -215,6 +215,7 @@ export const fallbackContent: SiteContent = {
     description: teacher.description,
     imageUrl: teacher.imageUrl,
     impactStatement: teacher.impactStatement,
+    isHeadmaster: teacher.isHeadmaster,
   })),
   program: {
     classes: programClasses,

--- a/lib/sanity-client.ts
+++ b/lib/sanity-client.ts
@@ -1,11 +1,10 @@
-import { createClient } from '@sanity/client';
-const config = {
-  projectId:
-    process.env.NEXT_PUBLIC_SANITY_PROJECT_ID ?? process.env.SANITY_PROJECT_ID,
-  dataset:
-    process.env.NEXT_PUBLIC_SANITY_DATASET ?? process.env.SANITY_DATASET,
-  useCdn: true, // set to `false` to bypass the edge cache
-  apiVersion: '2024-07-15', // use current date (YYYY-MM-DD) to target the latest API version
-};
+import { createClient } from "@sanity/client";
+import { apiVersion, dataset, projectId } from "@/sanity/env";
 
-export const sanityClient = createClient(config);
+export const sanityClient = createClient({
+  projectId,
+  dataset,
+  apiVersion,
+  useCdn: process.env.NODE_ENV === "production",
+  perspective: "published",
+});

--- a/lib/sanity.queries.ts
+++ b/lib/sanity.queries.ts
@@ -40,7 +40,7 @@ const SITE_CONTENT_QUERY = `*[_type == "siteContent"][0]{
     "officialProfile": aboutPage.officialProfile,
     "milestones": aboutPage.milestones[]{ year, title, description }
   },
-  "teachers": teachers[]{ name, position, description, impactStatement, "imageUrl": image.asset->url },
+  "teachers": teachers[]{ name, position, description, impactStatement, isHeadmaster, "imageUrl": image.asset->url },
   "program": {
     "classes": programPage.classes[]{ name, age, description, focus },
     "learningMethods": programPage.learningMethods[]{ title, description },

--- a/lib/types/site.ts
+++ b/lib/types/site.ts
@@ -74,9 +74,10 @@ export type AboutPageData = {
 export type TeacherProfile = {
   name: string;
   position: string;
-  description: string;
+  description?: string | null;
   imageUrl?: string | null;
   impactStatement?: string | null;
+  isHeadmaster?: boolean | null;
 };
 
 export type ProgramClass = {

--- a/sanity/schemas/siteContent.ts
+++ b/sanity/schemas/siteContent.ts
@@ -407,6 +407,12 @@ export const siteContent = defineType({
           fields: [
             defineField({ name: "name", title: "Nama", type: "string", validation: (rule) => rule.required() }),
             defineField({ name: "position", title: "Jabatan", type: "string", validation: (rule) => rule.required() }),
+            defineField({
+              name: "isHeadmaster",
+              title: "Tandai sebagai Kepala Sekolah",
+              type: "boolean",
+              description: "Centang bila profil ini adalah kepala sekolah untuk ditampilkan lebih menonjol.",
+            }),
             defineField({ name: "description", title: "Deskripsi", type: "text", rows: 3 }),
             defineField({ name: "impactStatement", title: "Pernyataan Dampak", type: "text", rows: 2 }),
             defineField({ name: "image", title: "Foto", type: "image", options: { hotspot: true } }),


### PR DESCRIPTION
## Summary
- configure the Sanity client with the shared env helper and fetch the new teacher headmaster flag
- extend the teacher schema, fallback data, and types with an explicit headmaster toggle
- update the about page teacher list to show headmaster/teacher cards with images and better fallbacks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcedca3990832fb0a8b6f9032476f9