### PR TITLE
Use Next.js Image component in facility and gallery pages

### DIFF
--- a/app/fasilitas/page.tsx
+++ b/app/fasilitas/page.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 import PageHeader from "@/components/layout/PageHeader";
 import PageSection from "@/components/layout/PageSection";
 import { createPageMetadata } from "@/lib/metadata";
@@ -83,10 +85,12 @@ export default async function FasilitasPage() {
                                 {/* Gambar Fasilitas */}
                                 <div className={`relative aspect-square lg:aspect-[4/3] rounded-xl bg-surfaceAlt border border-border flex items-center justify-center overflow-hidden shadow-md ${index % 2 === 1 ? 'lg:order-2' : ''}`}>
                                     {facility.image ? (
-                                        <img 
-                                            src={urlFor(facility.image).width(800).height(600).url()} 
-                                            alt={facility.name} 
-                                            className="w-full h-full object-cover transition-transform duration-300 hover:scale-105"
+                                        <Image
+                                            src={urlFor(facility.image).width(800).height(600).url()}
+                                            alt={facility.name}
+                                            fill
+                                            sizes="(min-width: 1024px) 50vw, 100vw"
+                                            className="object-cover transition-transform duration-300 hover:scale-105"
                                         />
                                     ) : (
                                         <div className="text-center text-text-muted">

--- a/app/galeri/page.tsx
+++ b/app/galeri/page.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import Link from "next/link";
 
 import PageHeader from "@/components/layout/PageHeader";
@@ -41,12 +42,15 @@ export default async function Page() {
                 key={item.id}
                 className="overflow-hidden rounded-3xl border border-border/60 bg-white shadow-sm transition hover:shadow-soft"
               >
-                <img
-                  src={item.imageUrl}
-                  alt={item.description || item.title}
-                  loading="lazy"
-                  className="h-56 w-full object-cover"
-                />
+                <div className="relative h-56 w-full">
+                  <Image
+                    src={item.imageUrl}
+                    alt={item.description || item.title}
+                    fill
+                    sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+                    className="object-cover"
+                  />
+                </div>
                 <figcaption className="space-y-1 p-4 text-base">
                   <p className="font-semibold text-text">{item.title}</p>
                   <p className="text-sm text-text-muted">{item.description}</p>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,6 +2,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
 import DesktopNav from '@/components/DesktopNav';
 import MobileNav from '@/components/MobileNav';
@@ -50,10 +51,13 @@ export default function Header() {
               className="flex shrink-0 items-center gap-3 text-text transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40"
             >
               <span className="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/60 bg-white/70 shadow-soft backdrop-blur-sm">
-                <img
-                  src={siteSettings.logoUrl ?? "/logo-minimal-full.png"}
+                <Image
+                  src={siteSettings.logoUrl ?? '/logo-minimal-full.png'}
                   alt={`Logo ${siteSettings.schoolName}`}
+                  width={32}
+                  height={32}
                   className="h-8 w-8 object-contain"
+                  priority
                 />
               </span>
               <span className="flex min-w-0 flex-col leading-tight">

--- a/sanity/schemas/author.js
+++ b/sanity/schemas/author.js
@@ -1,4 +1,4 @@
-export default {
+const author = {
   name: 'author',
   title: 'Penulis',
   type: 'document',
@@ -6,4 +6,6 @@ export default {
     { name: 'name', title: 'Nama', type: 'string' },
     { name: 'image', title: 'Foto', type: 'image' }
   ]
-}
+};
+
+export default author;


### PR DESCRIPTION
## Summary
- replace remaining `<img>` usages in the header, fasilitas, and galeri views with Next.js `Image`
- ensure responsive containers for gallery and facility imagery while keeping hover effects intact
- update the Sanity author schema export to satisfy eslint's no-anonymous-default-export rule

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd07a20858832fa3a97163832ac0e7