### PR TITLE
Restore animated header menu interactions

### DIFF
--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -1,12 +1,72 @@
 "use client";
 
-import { type TransitionEvent, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { AnimatePresence, motion, type Variants } from "framer-motion";
 import { ChevronDown } from "react-bootstrap-icons";
 
 import { useSiteData } from "@/app/providers/SiteDataProvider";
 import { cn } from "@/lib/utils";
+
+const smoothEase = [0.4, 0, 0.2, 1] as const;
+
+const menuVariants: Variants = {
+  hidden: {
+    opacity: 0,
+    y: "-100%",
+  },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      duration: 0.55,
+      ease: smoothEase,
+      delayChildren: 0.15,
+      staggerChildren: 0.08,
+    },
+  },
+  exit: {
+    opacity: 0,
+    y: "-100%",
+    transition: {
+      duration: 0.45,
+      ease: [0.4, 0, 1, 1],
+      when: "afterChildren",
+      staggerChildren: 0.06,
+      staggerDirection: -1,
+    },
+  },
+};
+
+const navItemVariants: Variants = {
+  hidden: {
+    opacity: 0,
+    y: 20,
+  },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      duration: 0.45,
+      ease: smoothEase,
+    },
+  },
+  exit: {
+    opacity: 0,
+    y: 20,
+    transition: {
+      duration: 0.3,
+      ease: "easeIn",
+    },
+  },
+};
+
+const accordionContentVariants: Variants = {
+  hidden: { opacity: 0, height: 0, transition: { duration: 0.35, ease: smoothEase } },
+  visible: { opacity: 1, height: "auto", transition: { duration: 0.45, ease: smoothEase } },
+  exit: { opacity: 0, height: 0, transition: { duration: 0.35, ease: smoothEase } },
+};
 
 interface MobileMenuProps {
   isOpen: boolean;
@@ -17,13 +77,6 @@ export default function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
   const pathname = usePathname();
   const { navigation } = useSiteData();
   const [openAccordion, setOpenAccordion] = useState<string | null>(null);
-  const [shouldRender, setShouldRender] = useState(isOpen);
-
-  useEffect(() => {
-    if (isOpen) {
-      setShouldRender(true);
-    }
-  }, [isOpen]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -46,113 +99,111 @@ export default function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, onClose]);
 
-  const handleTransitionEnd = (event: TransitionEvent<HTMLDivElement>) => {
-    if (event.target !== event.currentTarget) {
-      return;
-    }
-
-    if (!isOpen) {
-      setShouldRender(false);
-    }
-  };
-
   const toggleAccordion = (label: string) => {
     setOpenAccordion((current) => (current === label ? null : label));
   };
 
   const items = useMemo(() => navigation, [navigation]);
 
-  if (!shouldRender) {
-    return null;
-  }
-
   return (
-    <div
-      id="mobile-nav"
-      role="dialog"
-      aria-modal="true"
-      aria-hidden={!isOpen}
-      className={cn(
-        "fixed inset-0 z-40 overflow-y-auto bg-surface pt-24 pb-12 transition-opacity duration-200 ease-out",
-        isOpen ? "opacity-100" : "pointer-events-none opacity-0",
-      )}
-      onTransitionEnd={handleTransitionEnd}
-    >
-      <nav
-        className={cn(
-          "flex transform flex-col gap-1 px-4 text-xl font-medium text-text transition-transform duration-300 ease-out",
-          isOpen ? "translate-y-0" : "-translate-y-3",
-        )}
-      >
-        {items.map((item) => {
-          if ("children" in item) {
-            const isAccordionOpen = openAccordion === item.label;
+    <AnimatePresence mode="wait">
+      {isOpen && (
+        <motion.div
+          key="mobile-nav"
+          id="mobile-nav"
+          role="dialog"
+          aria-modal="true"
+          aria-hidden={!isOpen}
+          className="fixed inset-0 z-40 overflow-y-auto bg-surface pt-24 pb-12"
+          variants={menuVariants}
+          initial="hidden"
+          animate="visible"
+          exit="exit"
+        >
+          <nav className="flex flex-col gap-1 px-4 text-xl font-medium text-text">
+            {items.map((item) => {
+              if ("children" in item) {
+                const isAccordionOpen = openAccordion === item.label;
 
-            return (
-              <div key={item.label}>
-                <button
-                  onClick={() => toggleAccordion(item.label)}
-                  aria-expanded={isAccordionOpen}
-                  className="flex w-full items-center justify-between rounded-full px-4 py-2 text-left transition-colors duration-150 hover:bg-surfaceAlt focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40"
-                >
-                  <span className="font-semibold text-text">{item.label}</span>
-                  <ChevronDown
-                    className={cn(
-                      "h-5 w-5 text-text-muted transition-transform duration-200",
-                      isAccordionOpen ? "rotate-180" : "rotate-0",
-                    )}
-                    aria-hidden="true"
-                  />
-                </button>
-                {isAccordionOpen && (
-                  <div className="mt-2 flex flex-col gap-1 border-l border-border py-2 pl-4">
-                    {item.children.map((child) => {
-                      const isActive = pathname === child.href || pathname.startsWith(`${child.href}/`);
-                      return (
-                        <Link
-                          key={child.href}
-                          href={child.href}
-                          onClick={onClose}
-                          aria-current={isActive ? "page" : undefined}
-                          className={cn(
-                            "block rounded-full px-5 py-2 text-base transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40",
-                            isActive
-                              ? "text-pink-500"
-                              : "text-text-muted hover:bg-surfaceAlt hover:text-text",
-                          )}
+                return (
+                  <motion.div key={item.label} variants={navItemVariants}>
+                    <button
+                      onClick={() => toggleAccordion(item.label)}
+                      aria-expanded={isAccordionOpen}
+                      className="flex w-full items-center justify-between rounded-full px-4 py-2 text-left transition-colors duration-200 hover:bg-surfaceAlt focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40"
+                    >
+                      <span className="font-semibold text-text">{item.label}</span>
+                      <ChevronDown
+                        className={cn(
+                          "h-5 w-5 text-text-muted transition-transform duration-300",
+                          isAccordionOpen ? "rotate-180" : "rotate-0",
+                        )}
+                        aria-hidden="true"
+                      />
+                    </button>
+                    <AnimatePresence>
+                      {isAccordionOpen && (
+                        <motion.div
+                          key={`${item.label}-content`}
+                          className="overflow-hidden pl-4"
+                          variants={accordionContentVariants}
+                          initial="hidden"
+                          animate="visible"
+                          exit="exit"
                         >
-                          {child.label}
-                        </Link>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-            );
-          }
+                          <div className="mt-2 flex flex-col gap-1 border-l border-border py-2 pl-4">
+                            {item.children.map((child) => {
+                              const isActive = pathname === child.href || pathname.startsWith(`${child.href}/`);
+                              return (
+                                <Link
+                                  key={child.href}
+                                  href={child.href}
+                                  onClick={onClose}
+                                  aria-current={isActive ? "page" : undefined}
+                                  className={cn(
+                                    "block rounded-full px-5 py-2 text-base transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40",
+                                    isActive
+                                      ? "text-pink-500"
+                                      : "text-text-muted hover:bg-surfaceAlt hover:text-text",
+                                  )}
+                                >
+                                  {child.label}
+                                </Link>
+                              );
+                            })}
+                          </div>
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
+                  </motion.div>
+                );
+              }
 
-          if (!("href" in item) || !item.href) {
-            return null;
-          }
+              if (!("href" in item) || !item.href) {
+                return null;
+              }
 
-          const isActive = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
+              const isActive = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
 
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              onClick={onClose}
-              aria-current={isActive ? "page" : undefined}
-              className={cn(
-                "block rounded-full px-4 py-2 font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40",
-                isActive ? "bg-surfaceAlt font-semibold text-pink-500" : "text-text hover:bg-surfaceAlt",
-              )}
-            >
-              {item.label}
-            </Link>
-          );
-        })}
-      </nav>
-    </div>
+              return (
+                <motion.div key={item.href} variants={navItemVariants}>
+                  <Link
+                    href={item.href}
+                    onClick={onClose}
+                    aria-current={isActive ? "page" : undefined}
+                    className={cn(
+                      "block rounded-full px-4 py-2 font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40",
+                      isActive ? "bg-surfaceAlt font-semibold text-pink-500" : "text-text hover:bg-surfaceAlt",
+                    )}
+                  >
+                    {item.label}
+                  </Link>
+                </motion.div>
+              );
+            })}
+          </nav>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import { motion } from "framer-motion";
 
 interface MobileNavProps {
   isOpen: boolean;
@@ -10,31 +10,28 @@ interface MobileNavProps {
 export default function MobileNav({ isOpen, onToggle }: MobileNavProps) {
   return (
     <div className="relative z-50 lg:hidden">
-      <button
+      <motion.button
         type="button"
         onClick={onToggle}
         aria-expanded={isOpen}
         aria-controls="mobile-nav"
         className="relative z-50 inline-flex items-center justify-center p-2.5 text-text transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        whileTap={{ scale: 0.96 }}
       >
         <span className="sr-only">Toggle navigation</span>
         <span className="relative block h-5 w-6" aria-hidden>
-          <span
-            className={cn(
-              "absolute left-0 block h-0.5 w-full rounded bg-current transition-transform duration-200 ease-out",
-              isOpen ? "translate-y-2.5 rotate-45" : "translate-y-0 rotate-0",
-            )}
-            style={{ top: "6px" }}
+          <motion.span
+            className="absolute left-0 top-1 h-0.5 w-full rounded bg-current"
+            animate={isOpen ? { rotate: 45, y: 5 } : { rotate: 0, y: 0 }}
+            transition={{ duration: 0.32, ease: [0.4, 0, 0.2, 1] }}
           />
-          <span
-            className={cn(
-              "absolute left-0 block h-0.5 w-full rounded bg-current transition-transform duration-200 ease-out",
-              isOpen ? "-translate-y-2.5 -rotate-45" : "translate-y-0 rotate-0",
-            )}
-            style={{ bottom: "6px" }}
+          <motion.span
+            className="absolute left-0 bottom-1 h-0.5 w-full rounded bg-current"
+            animate={isOpen ? { rotate: -45, y: -5 } : { rotate: 0, y: 0 }}
+            transition={{ duration: 0.32, ease: [0.4, 0, 0.2, 1] }}
           />
         </span>
-      </button>
+      </motion.button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- restore the framer-motion hamburger animation for the mobile header toggle so the close icon aligns symmetrically
- reintroduce framer-motion transitions and staggered reveals for the mobile navigation overlay and accordion links

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd0b4140d0832f8c130ac58bace126