### PR TITLE
Fix HTTPS detection to avoid redirect issues

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,11 +2,17 @@ import { NextResponse, type NextRequest } from 'next/server';
 
 export function middleware(request: NextRequest) {
   if (process.env.NODE_ENV === 'production') {
-    const proto = request.headers.get('x-forwarded-proto');
+    const forwardedProto = request.headers.get('x-forwarded-proto');
+    const normalizedForwardedProto = forwardedProto
+      ?.split(',')[0]
+      ?.trim()
+      .toLowerCase();
+    const isForwardedHttps = normalizedForwardedProto === 'https';
+    const isRequestHttps = request.nextUrl.protocol === 'https:';
 
-    if (proto === 'http') {
+    if (!isForwardedHttps && !isRequestHttps) {
       const url = request.nextUrl.clone();
-      url.protocol = 'https';
+      url.protocol = 'https:';
       return NextResponse.redirect(url, 308);
     }
   }


### PR DESCRIPTION
## Summary
- normalize the forwarded protocol header and fall back to the request URL protocol before redirecting to HTTPS
- prevent unnecessary HTTPS redirects that can block access behind certain Wi-Fi proxies

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd0bfcc208832fbc7f73db2bf31ed1