### PR TITLE
Enable rich text editing for Sanity blog posts

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { Clock, Person } from 'react-bootstrap-icons';
 import Mdx from '@/components/mdx/Mdx';
 import EngagementSection from '@/components/blog/EngagementSection';
 import { createPageMetadata } from "@/lib/metadata";
-import { calculateReadingTime } from '@/lib/utils';
+import { calculateReadingTime, portableTextToPlainText } from '@/lib/utils';
 import { getGlobalSiteData } from '@/lib/sanity.queries';
 
 export const revalidate = 60; // refresh detail pages regularly for new/updated posts
@@ -34,9 +34,11 @@ export async function generateMetadata({ params }: BlogPageProps) {
     return notFound(); // Or return a default metadata object
   }
 
+  const description = portableTextToPlainText(post.body) || post.title;
+
   return createPageMetadata({
     title: post.title,
-    description: post.body.raw || post.title,
+    description,
     image: post.coverImage,
     path: `/blog/${post.slug}`,
     siteSettings,
@@ -51,7 +53,8 @@ export default async function BlogPostPage({ params }: BlogPageProps) {
     return notFound();
   }
 
-  const readingTime = Math.max(1, calculateReadingTime(post.body.raw));
+  const plainBody = portableTextToPlainText(post.body);
+  const readingTime = Math.max(1, calculateReadingTime(plainBody));
 
   return (
     <article className="bg-surfaceAlt">
@@ -94,7 +97,7 @@ export default async function BlogPostPage({ params }: BlogPageProps) {
 
           {/* Render the markdown content */}
           <div className="prose prose-lg mt-8 max-w-none prose-h2:text-2xl prose-h2:font-semibold prose-h2:text-text prose-p:text-text-muted prose-a:text-primary hover:prose-a:text-primary/80">
-            <Mdx code={post.body.raw} />
+            <Mdx value={post.body} />
           </div>
         </div>
         <div className="mx-auto mt-8 max-w-4xl">

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import PageHeader from '@/components/layout/PageHeader';
 import { getPosts, Post } from '@/lib/blog'; // Import Post from @/lib/blog
+import { portableTextToPlainText } from '@/lib/utils';
 import { ArrowRight } from 'react-bootstrap-icons';
 import { createPageMetadata } from '@/lib/metadata';
 import { getGlobalSiteData } from '@/lib/sanity.queries';
@@ -53,7 +54,7 @@ export default async function BlogListPage() {
 }
 
 function BlogCard({ post }: { post: Post }) {
-  const plainBody = post.body?.raw ? post.body.raw.replace(/\s+/g, ' ').trim() : '';
+  const plainBody = portableTextToPlainText(post.body);
   const truncatedBody = plainBody.slice(0, 100);
   const description = plainBody.length > 100 ? `${truncatedBody}...` : truncatedBody;
 

--- a/components/mdx/Mdx.tsx
+++ b/components/mdx/Mdx.tsx
@@ -1,17 +1,53 @@
 
 'use client';
 
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
+import { PortableText, type PortableTextComponents } from '@portabletext/react';
+import type { PortableTextBlock } from '@portabletext/types';
 
 type MdxProps = {
-  code: string;
+  value: PortableTextBlock[];
+};
+
+const components: PortableTextComponents = {
+  block: {
+    normal: ({ children }) => <p className="text-text-muted">{children}</p>,
+    h1: ({ children }) => <h1 className="text-3xl font-semibold text-text">{children}</h1>,
+    h2: ({ children }) => <h2 className="text-2xl font-semibold text-text">{children}</h2>,
+    h3: ({ children }) => <h3 className="text-xl font-semibold text-text">{children}</h3>,
+    h4: ({ children }) => <h4 className="text-lg font-semibold text-text">{children}</h4>,
+    blockquote: ({ children }) => (
+      <blockquote className="border-l-4 border-primary/30 pl-4 italic text-text-muted">{children}</blockquote>
+    ),
+  },
+  marks: {
+    link: ({ value, children }) => {
+      const href = value?.href as string | undefined;
+      if (!href) {
+        return <>{children}</>;
+      }
+      return (
+        <a href={href} className="text-primary underline underline-offset-4" target="_blank" rel="noopener noreferrer">
+          {children}
+        </a>
+      );
+    },
+    strong: ({ children }) => <strong className="font-semibold text-text">{children}</strong>,
+    em: ({ children }) => <em className="text-text-muted">{children}</em>,
+  },
+  list: {
+    bullet: ({ children }) => <ul className="list-disc space-y-2 pl-6 text-text-muted">{children}</ul>,
+    number: ({ children }) => <ol className="list-decimal space-y-2 pl-6 text-text-muted">{children}</ol>,
+  },
+  listItem: ({ children }) => <li>{children}</li>,
 };
 
 /**
- * A component to render markdown content.
- * It uses react-markdown with the GFM plugin to support tables, strikethroughs, etc.
+ * A component to render Sanity Portable Text content with Tailwind-friendly styles.
  */
-export default function Mdx({ code }: MdxProps) {
-  return <ReactMarkdown remarkPlugins={[remarkGfm]}>{code}</ReactMarkdown>;
+export default function Mdx({ value }: MdxProps) {
+  if (!value || value.length === 0) {
+    return null;
+  }
+
+  return <PortableText value={value} components={components} />;
 }

--- a/lib/blog-types.ts
+++ b/lib/blog-types.ts
@@ -1,11 +1,10 @@
+import type { PortableTextBlock } from '@portabletext/types';
+
 export interface Post {
   _id: string;
   title: string;
   date: string; // ISO 8601 date string
-  body: {
-    raw: string; // Markdown content
-    code: string; // Serialized MDX string (kept for compatibility)
-  };
+  body: PortableTextBlock[];
   slug: string;
   coverImage?: string;
   _raw: {

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -23,7 +23,19 @@ export async function getPosts(): Promise<Post[]> {
     _id,
     title,
     date,
-    "body": content,
+    "body": content[]{
+      ...,
+      markDefs[],
+      children[]{
+        ...,
+        _type == 'span' => {
+          text,
+          marks,
+          _type,
+          _key
+        }
+      }
+    },
     "slug": slug.current,
     "coverImage": mainImage.asset->url
   }`;
@@ -40,10 +52,7 @@ export async function getPosts(): Promise<Post[]> {
       _id: post._id,
       title: post.title,
       date: post.date,
-      body: {
-        raw: post.body || '',
-        code: post.body || '',
-      },
+      body: Array.isArray(post.body) ? post.body : [],
       slug: post.slug,
       coverImage: post.coverImage,
       _raw: {
@@ -71,7 +80,19 @@ export async function getPostBySlug(slug: string): Promise<Post | null> {
     _id,
     title,
     date,
-    "body": content,
+    "body": content[]{
+      ...,
+      markDefs[],
+      children[]{
+        ...,
+        _type == 'span' => {
+          text,
+          marks,
+          _type,
+          _key
+        }
+      }
+    },
     "slug": slug.current,
     "coverImage": mainImage.asset->url
   }`;
@@ -90,10 +111,7 @@ export async function getPostBySlug(slug: string): Promise<Post | null> {
       _id: post._id,
       title: post.title,
       date: post.date,
-      body: {
-        raw: post.body || '',
-        code: post.body || '',
-      },
+      body: Array.isArray(post.body) ? post.body : [],
       slug: post.slug,
       coverImage: post.coverImage,
       _raw: {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,6 @@
 
 import { type ClassValue, clsx } from "clsx";
+import type { PortableTextBlock } from '@portabletext/types';
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
@@ -12,4 +13,27 @@ export function calculateReadingTime(text: string): number {
   const wordCount = textContent.split(/\s+/).filter(Boolean).length;
   const readingTime = Math.ceil(wordCount / wordsPerMinute);
   return readingTime;
+}
+
+export function portableTextToPlainText(blocks: PortableTextBlock[] = []): string {
+  return blocks
+    .map((block) => {
+      if (!block || block._type !== 'block') {
+        return '';
+      }
+
+      const text = (block.children ?? [])
+        .map((child) => {
+          if (typeof child === 'object' && child && 'text' in child) {
+            return child.text ?? '';
+          }
+          return '';
+        })
+        .join('');
+
+      return text.trim();
+    })
+    .filter(Boolean)
+    .join('\n\n')
+    .trim();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@headlessui/react": "^2.2.9",
         "@heroicons/react": "^2.2.0",
         "@portabletext/react": "^4.0.3",
+        "@portabletext/types": "^2.0.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@sanity/client": "^7.11.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@headlessui/react": "^2.2.9",
     "@heroicons/react": "^2.2.0",
     "@portabletext/react": "^4.0.3",
+    "@portabletext/types": "^2.0.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@sanity/client": "^7.11.2",

--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -23,7 +23,10 @@ const blockContent = {
         { title: 'H4', value: 'h4' },
         { title: 'Quote', value: 'blockquote' }
       ],
-      lists: [{ title: 'Bullet', value: 'bullet' }],
+      lists: [
+        { title: 'Bullet', value: 'bullet' },
+        { title: 'Numbered', value: 'number' }
+      ],
       marks: {
         decorators: [{ title: 'Strong', value: 'strong' }, { title: 'Emphasis', value: 'em' }],
         annotations: [

--- a/sanity/schemas/post.ts
+++ b/sanity/schemas/post.ts
@@ -29,9 +29,8 @@ export const post = defineType({
     }),
     defineField({
       name: "content",
-      title: "Konten (Markdown)",
-      type: "text",
-      rows: 20,
+      title: "Konten",
+      type: "blockContent",
       validation: (rule) => rule.required(),
     }),
     defineField({


### PR DESCRIPTION
## Summary
- switch the Sanity blog schema to use the shared blockContent portable text definition so authors can add headings, quotes, and lists
- render blog content with @portabletext/react and surface plain-text helpers for metadata, reading time, and previews
- update fallback data and utilities to support the new portable text structure and add numbered list support in the block content schema

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd0c84c174832fa9f52f89c62b29b0