### PR TITLE
Guard Google Analytics script when measurement ID missing

### DIFF
--- a/components/GoogleAnalytics.tsx
+++ b/components/GoogleAnalytics.tsx
@@ -3,12 +3,21 @@
 
 import Script from 'next/script';
 
-const GA_MEASUREMENT_ID = 'G-FTRWM80D1S';
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
 
 export default function GoogleAnalytics() {
+  if (!GA_MEASUREMENT_ID) {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn(
+        'Google Analytics measurement ID is not set. Analytics script will not be loaded.'
+      );
+    }
+    return null;
+  }
+
   return (
     <>
-      <Script 
+      <Script
         strategy="afterInteractive"
         src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
       />


### PR DESCRIPTION
## Summary
- stop loading the Google Analytics script when no measurement ID is configured
- log a development warning so missing configuration is easy to spot

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd23e53d90832fbf307b91a52928af