### PR TITLE
Improve navigation active state color contrast

### DIFF
--- a/components/DesktopNav.tsx
+++ b/components/DesktopNav.tsx
@@ -30,7 +30,7 @@ export default function DesktopNav() {
                       <Popover.Button
                         className={`flex items-center gap-1 rounded-full px-4 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40 ${
                           isParentActive || open
-                            ? "bg-pink-500/10 text-pink-500"
+                            ? "bg-secondary/10 text-secondary-600"
                             : "text-text-muted hover:bg-surfaceAlt hover:text-text"
                         }`}
                       >
@@ -91,7 +91,7 @@ export default function DesktopNav() {
                 aria-current={isActive ? "page" : undefined}
                 className={`rounded-full px-4 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40 ${
                   isActive
-                    ? "bg-pink-500/10 text-pink-500"
+                    ? "bg-secondary/10 text-secondary-600"
                     : "text-text-muted hover:bg-surfaceAlt hover:text-text"
                 }`}
               >

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -163,7 +163,7 @@ export default function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
                                   className={cn(
                                     "block rounded-full px-5 py-2 text-base transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40",
                                     isActive
-                                      ? "text-pink-500"
+                                      ? "text-secondary-600"
                                       : "text-text-muted hover:bg-surfaceAlt hover:text-text",
                                   )}
                                 >
@@ -193,7 +193,7 @@ export default function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
                     aria-current={isActive ? "page" : undefined}
                     className={cn(
                       "block rounded-full px-4 py-2 font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40",
-                      isActive ? "bg-surfaceAlt font-semibold text-pink-500" : "text-text hover:bg-surfaceAlt",
+                      isActive ? "bg-secondary/10 font-semibold text-secondary-600" : "text-text hover:bg-surfaceAlt",
                     )}
                   >
                     {item.label}


### PR DESCRIPTION
## Summary
- adjust desktop navigation active styling to use secondary hues with sufficient contrast
- update mobile menu active link colors to match the improved contrast treatment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd25a31bdc832f9309acd288847862