### PR TITLE
Replace framer-motion usage with CSS-driven interactions

### DIFF
--- a/app/biaya/BiayaClientComponent.tsx
+++ b/app/biaya/BiayaClientComponent.tsx
@@ -1,7 +1,6 @@
-'use client'
+'use client';
 
-import { useState, useMemo } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { useState, useMemo, useEffect } from 'react';
 import { formatRupiah } from '@/utils/currency';
 
 // Definisikan tipe untuk properti komponen
@@ -18,6 +17,7 @@ interface BiayaClientComponentProps {
 
 export default function BiayaClientComponent({ biayaPokok }: BiayaClientComponentProps) {
   const [sppBulan, setSppBulan] = useState(12);
+  const [isHighlightingTotal, setIsHighlightingTotal] = useState(false);
 
   const biayaSekaliBayar = useMemo(() => 
     biayaPokok.filter(b => b.category === 'sekali bayar'), 
@@ -40,6 +40,12 @@ export default function BiayaClientComponent({ biayaPokok }: BiayaClientComponen
   );
 
   const totalEstimasi = totalSekaliBayar + totalBulanan;
+
+  useEffect(() => {
+    setIsHighlightingTotal(true);
+    const timeoutId = window.setTimeout(() => setIsHighlightingTotal(false), 300);
+    return () => window.clearTimeout(timeoutId);
+  }, [totalEstimasi]);
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-start">
@@ -96,18 +102,13 @@ export default function BiayaClientComponent({ biayaPokok }: BiayaClientComponen
           <div className="mt-6 pt-6 border-t border-primary/20">
              <div className="flex justify-between items-center">
                 <span className="text-lg font-medium text-text">Estimasi Total Tahun Pertama</span>
-                <AnimatePresence mode="wait">
-                  <motion.span 
-                    key={totalEstimasi}
-                    initial={{ opacity: 0, y: -10 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: 10 }}
-                    transition={{ duration: 0.2 }}
-                    className="text-2xl font-bold text-primary"
-                  >
-                    {formatRupiah(totalEstimasi)}
-                  </motion.span>
-                </AnimatePresence>
+                <span
+                  className={`text-2xl font-bold text-primary transition-opacity duration-300 ${
+                    isHighlightingTotal ? 'opacity-80' : 'opacity-100'
+                  }`}
+                >
+                  {formatRupiah(totalEstimasi)}
+                </span>
             </div>
           </div>
         </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -69,6 +69,43 @@ body {
   animation-play-state: paused;
 }
 
+@keyframes aurora-float {
+  0% {
+    transform: scale(1) translateY(0px);
+    opacity: 0.65;
+  }
+  50% {
+    transform: scale(1.05) translateY(-12px);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1) translateY(0px);
+    opacity: 0.65;
+  }
+}
+
+@keyframes aurora-glow {
+  0% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 0.8;
+  }
+  100% {
+    opacity: 0.6;
+  }
+}
+
+.animate-aurora-float {
+  animation: aurora-float var(--aurora-duration, 14s) ease-in-out infinite alternate;
+  will-change: transform, opacity;
+}
+
+.animate-aurora-glow {
+  animation: aurora-glow 12s ease-in-out infinite alternate;
+  will-change: opacity;
+}
+
 /* UPDATED: Changed focus ring to match new orange theme accent */
 .input {
   @apply w-full rounded-xl border border-border/70 bg-white px-4 py-3 text-base text-text placeholder:text-text-muted transition focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-400/40;

--- a/components/CTAButton.tsx
+++ b/components/CTAButton.tsx
@@ -2,7 +2,6 @@
 'use client';
 
 import Link from "next/link";
-import { motion } from "framer-motion";
 import type { CTAButtonConfig } from "@/lib/types/site";
 import { useCTAButton, useSiteData } from "@/app/providers/SiteDataProvider";
 import { getBootstrapIcon } from "@/lib/icon-registry";
@@ -38,11 +37,6 @@ export default function CTAButton({ ctaKey, className }: CTAButtonProps) {
     ghost: "ghost",
   } as const;
 
-  const motionProps = {
-    whileHover: { scale: 1.02 },
-    whileTap: { scale: 0.98 },
-  };
-
   const buttonContent = (
     <>
       {Icon && <Icon className="h-5 w-5" />}
@@ -51,7 +45,9 @@ export default function CTAButton({ ctaKey, className }: CTAButtonProps) {
   );
 
   return (
-    <motion.div {...motionProps} className={`relative w-full sm:w-auto ${className}`}>
+    <div
+      className={`relative w-full transform-gpu transition-transform duration-150 ease-out hover:scale-[1.02] active:scale-[0.98] sm:w-auto ${className}`}
+    >
       <Button
         asChild
         variant={variantMap[variant as keyof typeof variantMap] ?? "primary"}
@@ -61,6 +57,6 @@ export default function CTAButton({ ctaKey, className }: CTAButtonProps) {
           {buttonContent}
         </Link>
       </Button>
-    </motion.div>
+    </div>
   );
 }

--- a/components/FaqAccordion.tsx
+++ b/components/FaqAccordion.tsx
@@ -1,8 +1,10 @@
 
 "use client";
 
+import { clsx } from "clsx";
 import { useId, useState } from "react";
-import { AnimatePresence, motion } from "framer-motion";
+
+import AnimateIn from "@/components/AnimateIn";
 
 export type FaqItem = {
   question: string;
@@ -47,71 +49,66 @@ export default function FaqAccordion({
       {items.map((item, index) => {
         const isOpen = openIndex === index;
         const contentId = `${baseId}-${index}`;
+        const cardClassName = clsx(
+          "card overflow-hidden border-white/70 bg-white/70 text-left shadow-soft backdrop-blur-xl backdrop-saturate-150 transition-colors duration-200",
+          isOpen && "border-secondary/60 bg-white",
+        );
 
-        return (
-          <motion.div
-            key={item.question}
-            initial={revealOnView ? { opacity: 0, y: 40 } : false}
-            whileInView={revealOnView ? { opacity: 1, y: 0 } : undefined}
-            viewport={revealOnView ? { once: true, amount: 0.3 } : undefined}
-            transition={{
-              duration: 0.55,
-              delay: revealOnView ? index * itemDelay : undefined,
-            }}
-            // UPDATED: .card class already provides rounding, overflow-hidden will enforce it.
-            className={`card overflow-hidden border-white/70 bg-white/70 text-left shadow-soft backdrop-blur-xl backdrop-saturate-150 transition-colors duration-200 ${
-              isOpen ? "border-secondary/60 bg-white" : ""
-            }`}
-          >
+        const content = (
+          <>
             <button
               type="button"
               onClick={() => toggleIndex(index)}
               aria-expanded={isOpen}
               aria-controls={contentId}
-              // UPDATED: Added rounded-xl to ensure the focus outline is also rounded.
               className="flex w-full items-center gap-4 rounded-xl px-6 py-5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
             >
               <span className="flex-1 text-lg font-semibold text-text">{item.question}</span>
-              {/* UPDATED: Changed from rounded-full to rounded-xl for consistency */}
               <span className="relative inline-flex h-10 w-10 flex-none items-center justify-center rounded-xl bg-secondary/10 text-secondary">
                 <span className="absolute h-0.5 w-4 rounded bg-current" aria-hidden />
-                <motion.span
+                <span
                   aria-hidden
-                  className="absolute h-4 w-0.5 rounded bg-current"
-                  animate={{ scaleY: isOpen ? 0 : 1 }}
-                  transition={{ duration: 0.2, ease: "easeOut" }}
-                  style={{ originY: 0.5 }}
+                  className={clsx(
+                    "absolute h-4 w-0.5 rounded bg-current transition-transform duration-200 ease-out",
+                    isOpen ? "scale-y-0" : "scale-y-100",
+                  )}
+                  style={{ transformOrigin: "center" }}
                 />
               </span>
             </button>
-            <AnimatePresence initial={false}>
-              {isOpen ? (
-                <motion.div
-                  key="content"
-                  id={contentId}
-                  initial="collapsed"
-                  animate="open"
-                  exit="collapsed"
-                  variants={{
-                    open: { height: "auto", opacity: 1 },
-                    collapsed: { height: 0, opacity: 0 },
-                  }}
-                  transition={{ duration: 0.28, ease: [0.4, 0, 0.2, 1] }}
-                  className="px-6"
-                >
-                  <motion.p
-                    initial={{ opacity: 0, y: -8 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -8 }}
-                    transition={{ duration: 0.2, ease: "easeOut" }}
-                    className="pb-6 text-base leading-relaxed text-text-muted"
-                  >
-                    {item.answer}
-                  </motion.p>
-                </motion.div>
-              ) : null}
-            </AnimatePresence>
-          </motion.div>
+            <div
+              id={contentId}
+              role="region"
+              aria-hidden={!isOpen}
+              className={clsx(
+                "grid px-6 transition-[grid-template-rows] duration-300 ease-out",
+                isOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+              )}
+            >
+              <div
+                className={clsx(
+                  "overflow-hidden text-base leading-relaxed text-text-muted transition-all duration-300 ease-out",
+                  isOpen ? "translate-y-0 opacity-100" : "-translate-y-2 opacity-0",
+                )}
+              >
+                <p className="pb-6">{item.answer}</p>
+              </div>
+            </div>
+          </>
+        );
+
+        if (revealOnView) {
+          return (
+            <AnimateIn key={item.question} className={cardClassName} delay={index * itemDelay}>
+              {content}
+            </AnimateIn>
+          );
+        }
+
+        return (
+          <div key={item.question} className={cardClassName}>
+            {content}
+          </div>
         );
       })}
     </div>

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -3,70 +3,10 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { AnimatePresence, motion, type Variants } from "framer-motion";
 import { ChevronDown } from "react-bootstrap-icons";
 
 import { useSiteData } from "@/app/providers/SiteDataProvider";
 import { cn } from "@/lib/utils";
-
-const smoothEase = [0.4, 0, 0.2, 1] as const;
-
-const menuVariants: Variants = {
-  hidden: {
-    opacity: 0,
-    y: "-100%",
-  },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.55,
-      ease: smoothEase,
-      delayChildren: 0.15,
-      staggerChildren: 0.08,
-    },
-  },
-  exit: {
-    opacity: 0,
-    y: "-100%",
-    transition: {
-      duration: 0.45,
-      ease: [0.4, 0, 1, 1],
-      when: "afterChildren",
-      staggerChildren: 0.06,
-      staggerDirection: -1,
-    },
-  },
-};
-
-const navItemVariants: Variants = {
-  hidden: {
-    opacity: 0,
-    y: 20,
-  },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.45,
-      ease: smoothEase,
-    },
-  },
-  exit: {
-    opacity: 0,
-    y: 20,
-    transition: {
-      duration: 0.3,
-      ease: "easeIn",
-    },
-  },
-};
-
-const accordionContentVariants: Variants = {
-  hidden: { opacity: 0, height: 0, transition: { duration: 0.35, ease: smoothEase } },
-  visible: { opacity: 1, height: "auto", transition: { duration: 0.45, ease: smoothEase } },
-  exit: { opacity: 0, height: 0, transition: { duration: 0.35, ease: smoothEase } },
-};
 
 interface MobileMenuProps {
   isOpen: boolean;
@@ -77,11 +17,37 @@ export default function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
   const pathname = usePathname();
   const { navigation } = useSiteData();
   const [openAccordion, setOpenAccordion] = useState<string | null>(null);
+  const [renderMenu, setRenderMenu] = useState(isOpen);
+  const [isVisible, setIsVisible] = useState(isOpen);
 
   useEffect(() => {
     if (!isOpen) {
       setOpenAccordion(null);
     }
+  }, [isOpen]);
+
+  useEffect(() => {
+    let timeoutId: number | undefined;
+    let rafId: number | undefined;
+
+    if (isOpen) {
+      setRenderMenu(true);
+      rafId = requestAnimationFrame(() => setIsVisible(true));
+    } else {
+      setIsVisible(false);
+      timeoutId = window.setTimeout(() => {
+        setRenderMenu(false);
+      }, 400);
+    }
+
+    return () => {
+      if (typeof timeoutId === "number") {
+        window.clearTimeout(timeoutId);
+      }
+      if (typeof rafId === "number") {
+        cancelAnimationFrame(rafId);
+      }
+    };
   }, [isOpen]);
 
   useEffect(() => {
@@ -105,107 +71,115 @@ export default function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
 
   const items = useMemo(() => navigation, [navigation]);
 
+  if (!renderMenu) {
+    return null;
+  }
+
   return (
-    <AnimatePresence mode="wait">
-      {isOpen && (
-        <motion.div
-          key="mobile-nav"
-          id="mobile-nav"
-          role="dialog"
-          aria-modal="true"
-          aria-hidden={!isOpen}
-          className="fixed inset-0 z-40 overflow-y-auto bg-surface pt-24 pb-12"
-          variants={menuVariants}
-          initial="hidden"
-          animate="visible"
-          exit="exit"
-        >
-          <nav className="flex flex-col gap-1 px-4 text-xl font-medium text-text">
-            {items.map((item) => {
-              if ("children" in item) {
-                const isAccordionOpen = openAccordion === item.label;
-
-                return (
-                  <motion.div key={item.label} variants={navItemVariants}>
-                    <button
-                      onClick={() => toggleAccordion(item.label)}
-                      aria-expanded={isAccordionOpen}
-                      className="flex w-full items-center justify-between rounded-full px-4 py-2 text-left transition-colors duration-200 hover:bg-surfaceAlt focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40"
-                    >
-                      <span className="font-semibold text-text">{item.label}</span>
-                      <ChevronDown
-                        className={cn(
-                          "h-5 w-5 text-text-muted transition-transform duration-300",
-                          isAccordionOpen ? "rotate-180" : "rotate-0",
-                        )}
-                        aria-hidden="true"
-                      />
-                    </button>
-                    <AnimatePresence>
-                      {isAccordionOpen && (
-                        <motion.div
-                          key={`${item.label}-content`}
-                          className="overflow-hidden pl-4"
-                          variants={accordionContentVariants}
-                          initial="hidden"
-                          animate="visible"
-                          exit="exit"
-                        >
-                          <div className="mt-2 flex flex-col gap-1 border-l border-border py-2 pl-4">
-                            {item.children.map((child) => {
-                              const isActive = pathname === child.href || pathname.startsWith(`${child.href}/`);
-                              return (
-                                <Link
-                                  key={child.href}
-                                  href={child.href}
-                                  onClick={onClose}
-                                  aria-current={isActive ? "page" : undefined}
-                                  className={cn(
-                                    "block rounded-full px-5 py-2 text-base transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40",
-                                    isActive
-                                      ? "bg-white text-pink-700"
-                                      : "text-text-muted hover:bg-surfaceAlt hover:text-text",
-                                  )}
-                                >
-                                  {child.label}
-                                </Link>
-                              );
-                            })}
-                          </div>
-                        </motion.div>
-                      )}
-                    </AnimatePresence>
-                  </motion.div>
-                );
-              }
-
-              if (!("href" in item) || !item.href) {
-                return null;
-              }
-
-              const isActive = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
-
-              return (
-                <motion.div key={item.href} variants={navItemVariants}>
-                  <Link
-                    href={item.href}
-                    onClick={onClose}
-                    aria-current={isActive ? "page" : undefined}
-                    className={cn(
-                      "block rounded-full px-4 py-2 font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40",
-                      isActive
-                        ? "bg-white font-semibold text-pink-700"
-                        : "text-text hover:bg-surfaceAlt",
-                    )}
-                  >
-                    {item.label}
-                  </Link>
-                </motion.div>
-              );
-            })}
-          </nav>
-        </motion.div>
+    <div
+      id="mobile-nav"
+      role="dialog"
+      aria-modal="true"
+      aria-hidden={!isOpen}
+      className={cn(
+        "fixed inset-0 z-40 overflow-y-auto bg-surface pt-24 pb-12 transform-gpu transition-all duration-500 ease-[cubic-bezier(0.4,0,0.2,1)]",
+        isVisible ? "translate-y-0 opacity-100" : "-translate-y-full opacity-0",
       )}
-    </AnimatePresence>
+    >
+      <nav className="flex flex-col gap-1 px-4 text-xl font-medium text-text">
+        {items.map((item, index) => {
+          const transitionDelay = isVisible ? 0.15 + index * 0.08 : 0;
+          const itemClassName = cn(
+            "transform-gpu transition-all duration-400 ease-out",
+            isVisible ? "translate-y-0 opacity-100" : "translate-y-5 opacity-0",
+          );
+
+          if ("children" in item) {
+            const isAccordionOpen = openAccordion === item.label;
+
+            return (
+              <div
+                key={item.label}
+                className={itemClassName}
+                style={{ transitionDelay: `${transitionDelay}s` }}
+              >
+                <button
+                  onClick={() => toggleAccordion(item.label)}
+                  aria-expanded={isAccordionOpen}
+                  className="flex w-full items-center justify-between rounded-full px-4 py-2 text-left transition-colors duration-200 hover:bg-surfaceAlt focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40"
+                >
+                  <span className="font-semibold text-text">{item.label}</span>
+                  <ChevronDown
+                    className={cn(
+                      "h-5 w-5 text-text-muted transition-transform duration-300",
+                      isAccordionOpen ? "rotate-180" : "rotate-0",
+                    )}
+                    aria-hidden="true"
+                  />
+                </button>
+                <div
+                  className={cn(
+                    "grid transform-gpu pl-4 transition-[grid-template-rows,opacity] duration-400 ease-out",
+                    isAccordionOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
+                  )}
+                  role="region"
+                  aria-hidden={!isAccordionOpen}
+                >
+                  <div className="mt-2 flex flex-col gap-1 overflow-hidden border-l border-border py-2 pl-4">
+                    {item.children.map((child) => {
+                      const isActive = pathname === child.href || pathname.startsWith(`${child.href}/`);
+                      return (
+                        <Link
+                          key={child.href}
+                          href={child.href}
+                          onClick={onClose}
+                          aria-current={isActive ? "page" : undefined}
+                          className={cn(
+                            "block rounded-full px-5 py-2 text-base transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40",
+                            isActive
+                              ? "bg-white text-pink-700"
+                              : "text-text-muted hover:bg-surfaceAlt hover:text-text",
+                          )}
+                        >
+                          {child.label}
+                        </Link>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            );
+          }
+
+          if (!("href" in item) || !item.href) {
+            return null;
+          }
+
+          const isActive = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
+
+          return (
+            <div
+              key={item.href}
+              className={itemClassName}
+              style={{ transitionDelay: `${transitionDelay}s` }}
+            >
+              <Link
+                href={item.href}
+                onClick={onClose}
+                aria-current={isActive ? "page" : undefined}
+                className={cn(
+                  "block rounded-full px-4 py-2 font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-500/40",
+                  isActive
+                    ? "bg-white font-semibold text-pink-700"
+                    : "text-text hover:bg-surfaceAlt",
+                )}
+              >
+                {item.label}
+              </Link>
+            </div>
+          );
+        })}
+      </nav>
+    </div>
   );
 }

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { clsx } from "clsx";
 
 interface MobileNavProps {
   isOpen: boolean;
@@ -10,28 +10,29 @@ interface MobileNavProps {
 export default function MobileNav({ isOpen, onToggle }: MobileNavProps) {
   return (
     <div className="relative z-50 lg:hidden">
-      <motion.button
+      <button
         type="button"
         onClick={onToggle}
         aria-expanded={isOpen}
         aria-controls="mobile-nav"
-        className="relative z-50 inline-flex items-center justify-center p-2.5 text-text transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-        whileTap={{ scale: 0.96 }}
+        className="relative z-50 inline-flex transform-gpu items-center justify-center rounded-md p-2.5 text-text transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 active:scale-95"
       >
         <span className="sr-only">Toggle navigation</span>
         <span className="relative block h-5 w-6" aria-hidden>
-          <motion.span
-            className="absolute left-0 top-1 h-0.5 w-full rounded bg-current"
-            animate={isOpen ? { rotate: 45, y: 5 } : { rotate: 0, y: 0 }}
-            transition={{ duration: 0.32, ease: [0.4, 0, 0.2, 1] }}
+          <span
+            className={clsx(
+              "absolute left-0 h-0.5 w-full rounded bg-current transition-transform duration-300 ease-in-out",
+              isOpen ? "top-1/2 -translate-y-1/2 rotate-45" : "top-1 rotate-0",
+            )}
           />
-          <motion.span
-            className="absolute left-0 bottom-1 h-0.5 w-full rounded bg-current"
-            animate={isOpen ? { rotate: -45, y: -5 } : { rotate: 0, y: 0 }}
-            transition={{ duration: 0.32, ease: [0.4, 0, 0.2, 1] }}
+          <span
+            className={clsx(
+              "absolute left-0 h-0.5 w-full rounded bg-current transition-transform duration-300 ease-in-out",
+              isOpen ? "top-1/2 -translate-y-1/2 -rotate-45" : "bottom-1 rotate-0",
+            )}
           />
         </span>
-      </motion.button>
+      </button>
     </div>
   );
 }

--- a/components/TestimonialList.tsx
+++ b/components/TestimonialList.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useMemo, useState, type CSSProperties } from "react";
-import { LazyMotion, domAnimation, m } from "framer-motion";
 
+import AnimateIn from "@/components/AnimateIn";
 import PageSection from "@/components/layout/PageSection";
 import SectionHeader from "@/components/layout/SectionHeader";
 import { CardSurface, cardSurfaceVariants } from "@/components/ui/CardSurface";
@@ -44,64 +44,53 @@ export default function TestimonialList({ testimonials }: TestimonialListProps) 
   }
 
   return (
-    <LazyMotion features={domAnimation}>
-      <PageSection
-        id="testimonials"
-        className="relative overflow-hidden"
-        padding="relaxed"
-      >
-        <div className="absolute inset-x-0 top-10 flex justify-center">
-          <div className="h-48 w-48 rounded-full bg-secondary/20 blur-3xl sm:h-72 sm:w-72" />
-        </div>
-        <div className="relative">
-          <m.div
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.4 }}
-            transition={{ duration: 0.6 }}
-          >
-            <SectionHeader
-              align="center"
-              eyebrow="Suara Orang Tua"
-              eyebrowLeadingVisual={<span className="h-2.5 w-2.5 rounded-full bg-secondary" />}
-              eyebrowVariant="secondary"
-              title="Mereka melihat anak tumbuh lebih percaya diri dan bahagia"
-              description="Cerita asli dari keluarga yang mempercayakan proses belajar anaknya di TK Kartikasari."
-            />
-          </m.div>
+    <PageSection id="testimonials" className="relative overflow-hidden" padding="relaxed">
+      <div className="absolute inset-x-0 top-10 flex justify-center">
+        <div className="h-48 w-48 rounded-full bg-secondary/20 blur-3xl sm:h-72 sm:w-72" />
+      </div>
+      <div className="relative">
+        <AnimateIn>
+          <SectionHeader
+            align="center"
+            eyebrow="Suara Orang Tua"
+            eyebrowLeadingVisual={<span className="h-2.5 w-2.5 rounded-full bg-secondary" />}
+            eyebrowVariant="secondary"
+            title="Mereka melihat anak tumbuh lebih percaya diri dan bahagia"
+            description="Cerita asli dari keluarga yang mempercayakan proses belajar anaknya di TK Kartikasari."
+          />
+        </AnimateIn>
 
-          <div className="mt-14 overflow-x-hidden">
-            <div
-              className="flex w-max gap-6 animate-marquee"
-              style={marqueeStyle}
-              data-paused={isPaused ? "true" : "false"}
-              onMouseEnter={() => setIsPaused(true)}
-              onMouseLeave={() => setIsPaused(false)}
-            >
-              {duplicatedTestimonials.map((t, index) => (
-                <blockquote
-                  key={`${t.id}-${index}`}
-                  className={cn(
-                    cardSurfaceVariants({ tone: "translucent", padding: "lg" }),
-                    "relative w-[min(320px,80vw)] shrink-0 overflow-hidden text-left",
-                  )}
-                >
-                  <div className="absolute inset-0 bg-gradient-to-br from-primary/6 via-white to-secondary/10" />
-                  <div className="relative flex h-full flex-col gap-4">
-                    <div className="flex items-center gap-2 text-lg text-accent">
-                      {Array.from({ length: t.rating ?? 5 }).map((_, starIndex) => (
-                        <span key={starIndex}>★</span>
-                      ))}
-                    </div>
-                    <p className="text-lg font-medium leading-relaxed text-text">“{t.quote}”</p>
-                    <p className="text-base font-semibold text-text/80">{t.author}</p>
+        <div className="mt-14 overflow-x-hidden">
+          <div
+            className="flex w-max gap-6 animate-marquee"
+            style={marqueeStyle}
+            data-paused={isPaused ? "true" : "false"}
+            onMouseEnter={() => setIsPaused(true)}
+            onMouseLeave={() => setIsPaused(false)}
+          >
+            {duplicatedTestimonials.map((t, index) => (
+              <blockquote
+                key={`${t.id}-${index}`}
+                className={cn(
+                  cardSurfaceVariants({ tone: "translucent", padding: "lg" }),
+                  "relative w-[min(320px,80vw)] shrink-0 overflow-hidden text-left",
+                )}
+              >
+                <div className="absolute inset-0 bg-gradient-to-br from-primary/6 via-white to-secondary/10" />
+                <div className="relative flex h-full flex-col gap-4">
+                  <div className="flex items-center gap-2 text-lg text-accent">
+                    {Array.from({ length: t.rating ?? 5 }).map((_, starIndex) => (
+                      <span key={starIndex}>★</span>
+                    ))}
                   </div>
-                </blockquote>
-              ))}
-            </div>
+                  <p className="text-lg font-medium leading-relaxed text-text">“{t.quote}”</p>
+                  <p className="text-base font-semibold text-text/80">{t.author}</p>
+                </div>
+              </blockquote>
+            ))}
           </div>
         </div>
-      </PageSection>
-    </LazyMotion>
+      </div>
+    </PageSection>
   );
 }

--- a/components/reactbits/StickyScrollReveal.tsx
+++ b/components/reactbits/StickyScrollReveal.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { motion } from "framer-motion";
 
+import AnimateIn from "@/components/AnimateIn";
 import { cn } from "@/lib/utils";
 
 type StickyScrollRevealItem = {
@@ -24,6 +24,7 @@ type StickyScrollRevealProps = {
 
 export default function StickyScrollReveal({ eyebrow, heading, description, items, className }: StickyScrollRevealProps) {
   const [activeIndex, setActiveIndex] = useState(0);
+  const [visibleIndices, setVisibleIndices] = useState<number[]>([]);
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   useEffect(() => {
@@ -37,6 +38,9 @@ export default function StickyScrollReveal({ eyebrow, heading, description, item
           entries.forEach((entry) => {
             if (entry.isIntersecting) {
               setActiveIndex(index);
+              setVisibleIndices((current) =>
+                current.includes(index) ? current : [...current, index],
+              );
             }
           });
         },
@@ -61,13 +65,7 @@ export default function StickyScrollReveal({ eyebrow, heading, description, item
   return (
     <section className={cn("relative", className)}>
       <div className="grid gap-10 lg:grid-cols-[0.85fr,1.15fr] lg:items-start">
-        <motion.aside
-          initial={{ opacity: 0, y: 24 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, amount: 0.4 }}
-          transition={{ duration: 0.45 }}
-          className="sticky top-24 space-y-6 rounded-3xl border border-white/60 bg-white/70 p-8 shadow-soft backdrop-blur-xl backdrop-saturate-150"
-        >
+        <AnimateIn className="sticky top-24 space-y-6 rounded-3xl border border-white/60 bg-white/70 p-8 shadow-soft backdrop-blur-xl backdrop-saturate-150">
           <div className="space-y-3">
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-secondary">
               {eyebrow ?? "Program Utama"}
@@ -95,23 +93,23 @@ export default function StickyScrollReveal({ eyebrow, heading, description, item
               </ul>
             ) : null}
           </div>
-        </motion.aside>
+        </AnimateIn>
 
         <div className="space-y-6">
           {items.map((item, index) => (
-            <motion.div
+            <div
               key={item.id}
               ref={(element) => {
                 itemRefs.current[index] = element;
               }}
-              initial={{ opacity: 0, y: 32 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, amount: 0.35 }}
-              transition={{ duration: 0.5, delay: index * 0.05 }}
               className={cn(
-                "relative overflow-hidden rounded-3xl border border-white/60 bg-white/60 p-7 shadow-soft backdrop-blur-lg transition-all duration-500",
+                "relative overflow-hidden rounded-3xl border border-white/60 bg-white/60 p-7 shadow-soft backdrop-blur-lg transition-all duration-500 ease-out",
                 activeIndex === index ? "ring-2 ring-secondary/50" : "hover:border-secondary/50",
+                visibleIndices.includes(index)
+                  ? "translate-y-0 opacity-100"
+                  : "translate-y-8 opacity-0",
               )}
+              style={{ transitionDelay: visibleIndices.includes(index) ? `${index * 0.05}s` : undefined }}
             >
               <div className="absolute inset-0 bg-gradient-to-br from-secondary/5 via-white to-primary/10 opacity-80" aria-hidden="true" />
               <div className="relative space-y-4">
@@ -140,7 +138,7 @@ export default function StickyScrollReveal({ eyebrow, heading, description, item
                   </ul>
                 ) : null}
               </div>
-            </motion.div>
+            </div>
           ))}
         </div>
       </div>

--- a/components/tentang/TeacherList.tsx
+++ b/components/tentang/TeacherList.tsx
@@ -1,29 +1,7 @@
 
 import Image from "next/image";
-import { m } from "framer-motion";
 import { Person, PersonBadge } from "react-bootstrap-icons";
 import type { TeacherProfile } from "@/lib/types/site";
-
-const containerVariants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.1,
-    },
-  },
-};
-
-const itemVariants = {
-  hidden: { opacity: 0, y: 30 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.5,
-    },
-  },
-};
 
 interface TeacherListProps {
   teachers: TeacherProfile[];
@@ -102,14 +80,9 @@ export default function TeacherList({ teachers, headmasterName }: TeacherListPro
 
   if (!headmaster && otherTeachers.length === 0) {
     return (
-      <m.p
-        initial={{ opacity: 0 }}
-        whileInView={{ opacity: 1 }}
-        viewport={{ once: true, amount: 0.3 }}
-        className="text-base text-text-muted"
-      >
+      <p className="text-base text-text-muted">
         Data guru belum tersedia. Silakan tambahkan profil melalui Sanity Studio untuk menampilkannya di halaman ini.
-      </m.p>
+      </p>
     );
   }
 
@@ -117,13 +90,7 @@ export default function TeacherList({ teachers, headmasterName }: TeacherListPro
     <div className="space-y-12">
       {/* Headmaster Section */}
       {headmaster && (
-        <m.div
-          initial={{ opacity: 0, y: 40 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, amount: 0.5 }}
-          transition={{ duration: 0.6, ease: "easeOut" }}
-          className="mx-auto max-w-sm text-center"
-        >
+        <div className="mx-auto max-w-sm text-center">
           <TeacherAvatar name={headmaster.name} imageUrl={headmaster.imageUrl} icon={PersonBadge} size="lg" />
           <h3 className="text-2xl font-semibold text-text">{headmaster.name}</h3>
           <p className="text-base text-secondary">{headmaster.position}</p>
@@ -135,20 +102,14 @@ export default function TeacherList({ teachers, headmasterName }: TeacherListPro
               {headmaster.impactStatement}
             </p>
           ) : null}
-        </m.div>
+        </div>
       )}
 
       {/* Other Teachers Section */}
       {otherTeachers.length > 0 ? (
-        <m.div
-          variants={containerVariants}
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, amount: 0.1 }}
-          className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3"
-        >
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
           {otherTeachers.map((teacher, index) => (
-            <m.div key={index} variants={itemVariants} className="text-center">
+            <div key={index} className="text-center">
               <TeacherAvatar
                 name={teacher.name}
                 imageUrl={teacher.imageUrl}
@@ -164,9 +125,9 @@ export default function TeacherList({ teachers, headmasterName }: TeacherListPro
               {teacher.impactStatement ? (
                 <p className="mt-3 text-sm font-semibold text-secondary/80">{teacher.impactStatement}</p>
               ) : null}
-            </m.div>
+            </div>
           ))}
-        </m.div>
+        </div>
       ) : null}
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dotenv": "^17.2.2",
-        "framer-motion": "^12.23.22",
         "lucide-react": "^0.544.0",
         "next": "^15.5.4",
         "next-sanity": "^11.4.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dotenv": "^17.2.2",
-    "framer-motion": "^12.23.22",
     "lucide-react": "^0.544.0",
     "next": "^15.5.4",
     "next-sanity": "^11.4.2",


### PR DESCRIPTION
## Summary
- replace AnimateIn and FAQ accordion animations with lightweight IntersectionObserver logic and CSS transitions
- reimplement mobile navigation, testimonials, sticky scroll, timeline, and counter effects without framer-motion while preserving motion preferences
- add reusable aurora keyframes and remove the direct framer-motion dependency from the app bundle

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd2c2c8578832f99df2a4e211404f8