### PR TITLE
Increase Sanity fetch timeout to reduce build errors

### DIFF
--- a/lib/sanity-client.ts
+++ b/lib/sanity-client.ts
@@ -9,7 +9,7 @@ const parsedTimeout = Number.parseInt(
   10,
 );
 const DEFAULT_FETCH_TIMEOUT_MS = Number.isNaN(parsedTimeout)
-  ? 1000
+  ? 10000
   : Math.max(0, parsedTimeout);
 
 const NETWORK_ERROR_CODES = new Set([


### PR DESCRIPTION
## Summary
- increase the default Sanity fetch timeout to 10 seconds so build-time data requests are less likely to abort

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df3cdf85b0832f92d08001f82a429d