### PR TITLE
Relax Sanity runtime timeout and centralize skip message

### DIFF
--- a/app/fasilitas/page.tsx
+++ b/app/fasilitas/page.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import PageHeader from "@/components/layout/PageHeader";
 import PageSection from "@/components/layout/PageSection";
 import { createPageMetadata } from "@/lib/metadata";
-import { fetchSanityData } from "@/lib/sanity-client";
+import { SANITY_NETWORK_SKIP_MESSAGE, fetchSanityData } from "@/lib/sanity-client";
 import { urlFor } from "@/lib/sanity-image";
 import { CheckCircle, Image as ImageIcon, PlayCircleFill } from "react-bootstrap-icons";
 import AnimateIn from "@/components/AnimateIn";
@@ -28,7 +28,6 @@ type Facility = {
     image?: unknown;
 };
 
-const SANITY_SKIP_MESSAGE = "Sanity fetch skipped after previous network failure";
 let hasLoggedFasilitasError = false;
 let hasLoggedFasilitasSkip = false;
 
@@ -53,7 +52,7 @@ async function getFacilitiesData(): Promise<{ virtualTour: VirtualTour; faciliti
         } else if (
             !hasLoggedFasilitasSkip &&
             error instanceof Error &&
-            error.message.includes(SANITY_SKIP_MESSAGE)
+            error.message.includes(SANITY_NETWORK_SKIP_MESSAGE)
         ) {
             console.warn('Skipping fasilitas fetch after previous Sanity network failure.');
             hasLoggedFasilitasSkip = true;

--- a/app/pengumuman/[slug]/page.tsx
+++ b/app/pengumuman/[slug]/page.tsx
@@ -1,5 +1,5 @@
 
-import { fetchSanityData } from "@/lib/sanity-client";
+import { SANITY_NETWORK_SKIP_MESSAGE, fetchSanityData } from "@/lib/sanity-client";
 import { PortableText } from "@portabletext/react";
 import type { PortableTextBlock } from '@portabletext/types';
 import { notFound } from 'next/navigation';
@@ -13,7 +13,6 @@ type NewsDetail = {
   body: PortableTextBlock[];
 };
 
-const SANITY_SKIP_MESSAGE = "Sanity fetch skipped after previous network failure";
 let hasLoggedPengumumanDetailError = false;
 let hasLoggedPengumumanDetailSkip = false;
 
@@ -30,7 +29,7 @@ async function getNewsDetail(slug: string): Promise<NewsDetail | null> {
     } else if (
       !hasLoggedPengumumanDetailSkip &&
       error instanceof Error &&
-      error.message.includes(SANITY_SKIP_MESSAGE)
+      error.message.includes(SANITY_NETWORK_SKIP_MESSAGE)
     ) {
       console.warn('Skipping pengumuman detail fetch after previous Sanity network failure.');
       hasLoggedPengumumanDetailSkip = true;

--- a/app/pengumuman/page.tsx
+++ b/app/pengumuman/page.tsx
@@ -1,9 +1,8 @@
-import { fetchSanityData } from '@/lib/sanity-client';
+import { SANITY_NETWORK_SKIP_MESSAGE, fetchSanityData } from '@/lib/sanity-client';
 import Link from 'next/link';
 import { createPageMetadata } from '@/lib/metadata';
 import { getGlobalSiteData } from '@/lib/sanity.queries';
 
-const SANITY_SKIP_MESSAGE = 'Sanity fetch skipped after previous network failure';
 let hasLoggedPengumumanListError = false;
 let hasLoggedPengumumanListSkip = false;
 
@@ -28,7 +27,7 @@ async function getNewsData(): Promise<NewsItem[]> {
     } else if (
       !hasLoggedPengumumanListSkip &&
       error instanceof Error &&
-      error.message.includes(SANITY_SKIP_MESSAGE)
+      error.message.includes(SANITY_NETWORK_SKIP_MESSAGE)
     ) {
       console.warn('Skipping pengumuman fetch after previous Sanity network failure.');
       hasLoggedPengumumanListSkip = true;

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -1,4 +1,4 @@
-import { fetchSanityData } from './sanity-client';
+import { SANITY_NETWORK_SKIP_MESSAGE, fetchSanityData } from './sanity-client';
 import type { Post } from './blog-types';
 import { fallbackPosts } from '@/data/blog-posts';
 
@@ -17,7 +17,7 @@ let hasLoggedSinglePostSkip = false;
 function isSkipAfterNetworkFailure(error: unknown): error is Error {
   return (
     error instanceof Error &&
-    error.message.includes('Sanity fetch skipped after previous network failure')
+    error.message.includes(SANITY_NETWORK_SKIP_MESSAGE)
   );
 }
 

--- a/lib/sanity-client.ts
+++ b/lib/sanity-client.ts
@@ -8,8 +8,13 @@ const parsedTimeout = Number.parseInt(
   process.env.SANITY_FETCH_TIMEOUT_MS ?? "",
   10,
 );
+
+const DEFAULT_BUILD_FETCH_TIMEOUT_MS = 10_000;
+const DEFAULT_RUNTIME_FETCH_TIMEOUT_MS = 8_000;
 const DEFAULT_FETCH_TIMEOUT_MS = Number.isNaN(parsedTimeout)
-  ? 1000
+  ? process.env.NEXT_RUNTIME
+    ? DEFAULT_RUNTIME_FETCH_TIMEOUT_MS
+    : DEFAULT_BUILD_FETCH_TIMEOUT_MS
   : Math.max(0, parsedTimeout);
 
 const NETWORK_ERROR_CODES = new Set([
@@ -22,7 +27,24 @@ const NETWORK_ERROR_CODES = new Set([
   "ENETUNREACH",
 ]);
 
-let skipSanityRequests = false;
+export const SANITY_NETWORK_SKIP_MESSAGE =
+  "Sanity fetch skipped after previous network failure";
+const SKIP_SANITY_REQUESTS_DURATION_MS = 60_000;
+
+let skipSanityRequestsUntil = 0;
+
+function shouldSkipSanityRequests() {
+  if (skipSanityRequestsUntil === 0) {
+    return false;
+  }
+
+  if (skipSanityRequestsUntil <= Date.now()) {
+    skipSanityRequestsUntil = 0;
+    return false;
+  }
+
+  return true;
+}
 
 export const sanityClient = createClient({
   projectId,
@@ -37,10 +59,8 @@ export async function fetchSanityData<T>(
   params: SanityQueryParams = {},
   timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
 ): Promise<T> {
-  if (skipSanityRequests) {
-    throw new Error(
-      "Sanity fetch skipped after previous network failure.",
-    );
+  if (shouldSkipSanityRequests()) {
+    throw new Error(`${SANITY_NETWORK_SKIP_MESSAGE}.`);
   }
 
   const controller = new AbortController();
@@ -74,11 +94,12 @@ export async function fetchSanityData<T>(
 
   try {
     const result = await timedFetch;
-    skipSanityRequests = false;
+    skipSanityRequestsUntil = 0;
     return result;
   } catch (error) {
     if (isNetworkError(error)) {
-      skipSanityRequests = true;
+      skipSanityRequestsUntil =
+        Date.now() + SKIP_SANITY_REQUESTS_DURATION_MS;
     }
 
     throw error;

--- a/lib/sanity.queries.ts
+++ b/lib/sanity.queries.ts
@@ -1,6 +1,9 @@
 import { cache } from "react";
 
-import { fetchSanityData } from "@/lib/sanity-client";
+import {
+  SANITY_NETWORK_SKIP_MESSAGE,
+  fetchSanityData,
+} from "@/lib/sanity-client";
 import { fallbackContent } from "@/lib/fallback-content";
 import type { SiteContent } from "@/lib/types/site";
 
@@ -182,7 +185,7 @@ export const getSiteContent = cache(async (): Promise<SiteContent> => {
     } else if (
       !hasLoggedSiteContentSkip &&
       error instanceof Error &&
-      error.message.includes("Sanity fetch skipped after previous network failure")
+      error.message.includes(SANITY_NETWORK_SKIP_MESSAGE)
     ) {
       console.warn("Sanity fetch skipped after previous network failure.");
       hasLoggedSiteContentSkip = true;


### PR DESCRIPTION
## Summary
- raise the default runtime Sanity fetch timeout to 8 seconds so slower connections can finish requests before aborting
- export the Sanity network skip message and reuse it across all callers for consistent error handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df3cdf85b0832f92d08001f82a429d